### PR TITLE
fix: port mapping in prod docker

### DIFF
--- a/examples/ui/docker-compose.prod.yml
+++ b/examples/ui/docker-compose.prod.yml
@@ -28,7 +28,7 @@ services:
       - NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL:-http://localhost:8001}
       - NEXT_PUBLIC_USE_AUTH=${NEXT_PUBLIC_USE_AUTH:-false}
     ports:
-      - "3000:80"
+      - "3000:3000"
     depends_on:
       - backend
     networks:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix port mapping for `frontend` service in `docker-compose.prod.yml` from `3000:80` to `3000:3000`.
> 
>   - **Docker Compose**:
>     - Fix port mapping for `frontend` service in `docker-compose.prod.yml` from `3000:80` to `3000:3000`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=sinaptik-ai%2Fpanda-agi&utm_source=github&utm_medium=referral)<sup> for 22c8c4db4942a8e12928c8cb1a962d1525147555. You can [customize](https://app.ellipsis.dev/sinaptik-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->