### PR TITLE
fix: markdown for user message card

### DIFF
--- a/examples/ui/frontend/src/components/message-card.tsx
+++ b/examples/ui/frontend/src/components/message-card.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { AlertCircle } from "lucide-react";
 import { formatTimestamp } from "@/lib/date";
 import { Message } from "@/lib/types/event-message";
+import MarkdownRenderer from "./ui/markdown-renderer";
 
 
 interface MessageCardProps {
@@ -13,7 +14,9 @@ const MessageCard: React.FC<MessageCardProps> = ({ message }) => {
     return (
       <div className="flex justify-end">
         <div className="chat-message bg-blue-500 text-white max-w-xs lg:max-w-md min-w-48">
-          <p className="text-sm">{message.content}</p>
+          <div className="text-sm">
+            <MarkdownRenderer className="text-white" children={message.content || ""} />
+          </div>
           <p className="text-xs text-blue-100 mt-1 text-right">
             {message.timestamp && formatTimestamp(message.timestamp)}
           </p>
@@ -29,7 +32,9 @@ const MessageCard: React.FC<MessageCardProps> = ({ message }) => {
           <div className="flex items-start space-x-2">
             <AlertCircle className="w-5 h-5 mt-0.5 flex-shrink-0" />
             <div className="flex-1">
-              <p className="text-sm">{message.content}</p>
+              <div className="text-sm">
+                <MarkdownRenderer className="text-red-800" children={message.content || ""} />
+              </div>
               <p className="text-xs text-red-600 mt-1 text-right">
                 {message.timestamp && formatTimestamp(message.timestamp)}
               </p>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Replaces plain text with `MarkdownRenderer` for `message.content` in `MessageCard` to support markdown rendering for user and error messages.
> 
>   - **Behavior**:
>     - Replaces plain text rendering with `MarkdownRenderer` for `message.content` in `MessageCard` component.
>     - Affects both user (`message.type === "user"`) and error (`message.type === "error"`) message types.
>   - **Components**:
>     - Imports `MarkdownRenderer` in `message-card.tsx` and uses it to render `message.content`.
>   - **UI**:
>     - Ensures markdown content is displayed correctly in user and error message cards.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=sinaptik-ai%2Fpanda-agi&utm_source=github&utm_medium=referral)<sup> for 10f245819bfb7439476a25f161550ac70804a4df. You can [customize](https://app.ellipsis.dev/sinaptik-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->