### PR TITLE
fix: hardcode e2b env template

### DIFF
--- a/examples/ui/.env.example
+++ b/examples/ui/.env.example
@@ -2,4 +2,6 @@ WORKSPACE_PATH=./workspace
 FASTAPI_RELOAD=false
 PANDA_AGI_KEY=
 TAVILY_API_KEY=
-E2B_API_KEY=
+E2B_API_KEY= # Optional
+E2B_TEMPLATE= # Optional
+ENV=local   # Optional

--- a/examples/ui/backend/services/chat_env.py
+++ b/examples/ui/backend/services/chat_env.py
@@ -7,6 +7,8 @@ from panda_agi.envs.local_env import LocalEnv
 
 WORKSPACE_PATH = os.getenv("WORKSPACE_PATH", "./workspace")
 
+E2B_TEMPLATE = os.getenv("E2B_TEMPLATE", "ytj4es1gv3a3r7gqfyu5")
+
 
 async def get_env(metadata: Optional[Dict[str, Any]] = None, force_new: bool = False):
     env = os.getenv("ENV", "local")
@@ -16,14 +18,20 @@ async def get_env(metadata: Optional[Dict[str, Any]] = None, force_new: bool = F
             sandbox = await E2BEnv.get_active_sandbox(metadata)
             if sandbox:
                 return E2BEnv(
-                    "/workspace",
+                    template=E2B_TEMPLATE,
+                    base_path="/workspace",
                     metadata=metadata,
                     timeout=1800,
                     sandbox=sandbox,
                 )
 
         if not sandbox:
-            sandbox = E2BEnv("/workspace", metadata=metadata, timeout=1800)
+            sandbox = E2BEnv(
+                template=E2B_TEMPLATE,
+                base_path="/workspace",
+                metadata=metadata,
+                timeout=1800,
+            )
             await sandbox.create()
 
         return sandbox


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Hardcode E2B environment template in `chat_env.py` and `e2b_env.py`, updating environment variable handling and requiring a template parameter in `E2BEnv`.
> 
>   - **Environment Variables**:
>     - Add `E2B_TEMPLATE` and `ENV` to `examples/ui/.env.example`.
>     - Default `E2B_TEMPLATE` to `ytj4es1gv3a3r7gqfyu5` in `chat_env.py`.
>   - **E2BEnv Class**:
>     - Add `template` parameter to `E2BEnv.__init__()` in `e2b_env.py`.
>     - Modify `E2BEnv.create()` to check for `template` and pass it to `_connect()`.
>     - Update `_connect()` to require `template` parameter.
>   - **Behavior**:
>     - `get_env()` in `chat_env.py` now uses `E2B_TEMPLATE` for sandbox creation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=sinaptik-ai%2Fpanda-agi&utm_source=github&utm_medium=referral)<sup> for 3adaa42ceb1f09d1f9229324e70770222af2cb0c. You can [customize](https://app.ellipsis.dev/sinaptik-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->