### PR TITLE
fix: pdf paths after download

### DIFF
--- a/examples/ui/backend/routes/artifacts.py
+++ b/examples/ui/backend/routes/artifacts.py
@@ -40,7 +40,6 @@ def get_base_artifact_url(artifact_id: str, is_public: bool = False) -> str:
     Get the base artifact URL constructed from the source domain.
 
     Args:
-        request: The FastAPI request object
         artifact_id: The artifact ID
         is_public: Whether this is a public artifact
 

--- a/examples/ui/frontend/next.config.ts
+++ b/examples/ui/frontend/next.config.ts
@@ -4,24 +4,28 @@ const nextConfig: NextConfig = {
   // Enable standalone output for Docker optimization
   output: 'standalone',
   
-  // Handle redirects at the frontend level first
-  async redirects() {
-    return [
-      {
-        source: '/creations/:artifact_id',
-        destination: '/creations/:artifact_id/index.html',
-        permanent: false,
-      },
-    ];
-  },
+  // // Handle redirects at the frontend level first
+  // async redirects() {
+  //   return [
+  //     {
+  //       source: '/creations/:artifact_id',
+  //       destination: '/creations/:artifact_id/index.html',
+  //       permanent: false,
+  //     },
+  //   ];
+  // },
   
   // Proxy configuration for public artifacts
   async rewrites() {
     return [
       {
-        source: '/creations/:artifact_id/:path*',
+        source: '/creations/share/:artifact_id/:path*',
         destination: `${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8001'}/artifacts/public/:artifact_id/:path*`,
       },
+      {
+        source: '/creations/private/:artifact_id/:path*',
+        destination: `${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8001'}/artifacts/:artifact_id/:path*`,
+      }
     ];
   },
 };

--- a/examples/ui/frontend/src/app/creations/page.tsx
+++ b/examples/ui/frontend/src/app/creations/page.tsx
@@ -159,7 +159,7 @@ export default function CreationsPage() {
       return;
     }
 
-    const shareUrl = `${window.location.origin}/creations/${artifact.id}/${encodeURIComponent(artifact.filepath)}`;
+    const shareUrl = `${window.location.origin}/creations/share/${artifact.id}/${encodeURIComponent(artifact.filepath)}`;
     
     try {
       await navigator.clipboard.writeText(shareUrl);

--- a/examples/ui/frontend/src/components/artifact-viewer.tsx
+++ b/examples/ui/frontend/src/components/artifact-viewer.tsx
@@ -13,6 +13,7 @@ export interface ArtifactData {
   filepath: string;
   conversation_id: string;
   created_at: string;
+  is_public: boolean;
   metadata: Record<string, unknown>;
 }
 
@@ -135,6 +136,10 @@ const ArtifactViewer: React.FC<ArtifactViewerProps> = ({
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  const isPublic = artifact?.is_public || false
+
+  const fileBaseUrl = `${window.location.origin}/creations/${isPublic ? "share" : "private"}/${artifact?.id}/`
+
   // Fetch file content when artifact changes
   useEffect(() => {
     if (!artifact) {
@@ -155,9 +160,7 @@ const ArtifactViewer: React.FC<ArtifactViewerProps> = ({
     setError(null);
 
     try {
-      const fileUrl = getBackendServerURL(
-        `/artifacts/${artifact.id}/${encodeURIComponent(artifact.filepath)}?raw=true`
-      );
+      const fileUrl = `${fileBaseUrl}/${encodeURIComponent(artifact.filepath)}?raw=true`;
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const apiHeaders: any = await getApiHeaders();
@@ -228,11 +231,10 @@ const ArtifactViewer: React.FC<ArtifactViewerProps> = ({
       );
     }
 
+    const fileUrl = `${window.location.origin}/creations/${isPublic ? "share" : "private"}/${artifact?.id}/`
+
     switch (type) {
       case "markdown":
-        const fileUrl = getBackendServerURL(
-            `/artifacts/${artifact.id}/`
-          );
         return (
           <div className="prose prose-sm max-w-none">
             <MarkdownRenderer baseUrl={fileUrl}>{content}</MarkdownRenderer>
@@ -242,9 +244,7 @@ const ArtifactViewer: React.FC<ArtifactViewerProps> = ({
         return (
           <div className="h-full">
             <iframe
-              src={getBackendServerURL(
-                `/artifacts/${artifact.id}/${encodeURIComponent(artifact.filepath)}`
-              )}
+              src={`${fileUrl}/${encodeURIComponent(artifact.filepath)}`}
               className="w-full h-full border-0"
               title={artifact.name}
               sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
@@ -283,11 +283,7 @@ const ArtifactViewer: React.FC<ArtifactViewerProps> = ({
             {artifact.name}
           </h3>
           <a
-              href={
-                getBackendServerURL(
-                    `/artifacts/${artifact.id}/${encodeURIComponent(artifact.filepath)}`
-                  )
-              }
+              href={`${fileBaseUrl}/${encodeURIComponent(artifact.filepath)}`}
               target="_blank"
               rel="noopener noreferrer"
               className="text-xs text-blue-600 hover:underline flex items-center space-x-1 mt-1"

--- a/examples/ui/frontend/src/components/artifact-viewer.tsx
+++ b/examples/ui/frontend/src/components/artifact-viewer.tsx
@@ -160,7 +160,7 @@ const ArtifactViewer: React.FC<ArtifactViewerProps> = ({
     setError(null);
 
     try {
-      const fileUrl = `${fileBaseUrl}/${encodeURIComponent(artifact.filepath)}?raw=true`;
+      const fileUrl = `${fileBaseUrl}${encodeURIComponent(artifact.filepath)}?raw=true`;
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const apiHeaders: any = await getApiHeaders();

--- a/examples/ui/frontend/src/components/artifact-viewer.tsx
+++ b/examples/ui/frontend/src/components/artifact-viewer.tsx
@@ -231,20 +231,19 @@ const ArtifactViewer: React.FC<ArtifactViewerProps> = ({
       );
     }
 
-    const fileUrl = `${window.location.origin}/creations/${isPublic ? "share" : "private"}/${artifact?.id}/`
 
     switch (type) {
       case "markdown":
         return (
           <div className="prose prose-sm max-w-none">
-            <MarkdownRenderer baseUrl={fileUrl}>{content}</MarkdownRenderer>
+            <MarkdownRenderer baseUrl={fileBaseUrl}>{content}</MarkdownRenderer>
           </div>
         );
       case "iframe":
         return (
           <div className="h-full">
             <iframe
-              src={`${fileUrl}/${encodeURIComponent(artifact.filepath)}`}
+              src={`${fileBaseUrl}${encodeURIComponent(artifact.filepath)}`}
               className="w-full h-full border-0"
               title={artifact.name}
               sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
@@ -283,7 +282,7 @@ const ArtifactViewer: React.FC<ArtifactViewerProps> = ({
             {artifact.name}
           </h3>
           <a
-              href={`${fileBaseUrl}/${encodeURIComponent(artifact.filepath)}`}
+              href={`${fileBaseUrl}${encodeURIComponent(artifact.filepath)}`}
               target="_blank"
               rel="noopener noreferrer"
               className="text-xs text-blue-600 hover:underline flex items-center space-x-1 mt-1"

--- a/examples/ui/frontend/src/components/ui/markdown-renderer.tsx
+++ b/examples/ui/frontend/src/components/ui/markdown-renderer.tsx
@@ -148,7 +148,6 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
     ) {
       return url;
     }
-
     return new URL(url, baseUrl).toString();
   };
 
@@ -222,7 +221,7 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
               if (!transformedHref) {
                 return <span>{children}</span>;
               }
-              
+
               if (onPreviewClick) {
                 return (
                   <button


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes PDF path handling by updating URL construction for public and private artifacts in both backend and frontend.
> 
>   - **Backend**:
>     - Add `get_base_artifact_url()` in `artifacts.py` to construct URLs for public and private artifacts.
>     - Update `process_artifact_markdown_to_pdf()` in `artifacts.py` to use `base_source_url` for resolving paths.
>     - Modify `_get_public_artifact_file()` and `get_artifact_file()` in `artifacts.py` to use `get_base_artifact_url()`.
>   - **Frontend**:
>     - Update `next.config.ts` to adjust rewrites for public and private artifact paths.
>     - Modify `CreationsPage` in `page.tsx` to use new URL structure for sharing links.
>     - Update `ArtifactViewer` in `artifact-viewer.tsx` to handle new URL paths for fetching content.
>     - Adjust `MarkdownRenderer` in `markdown-renderer.tsx` to transform URLs based on new base paths.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=sinaptik-ai%2Fpanda-agi&utm_source=github&utm_medium=referral)<sup> for 4c0818da6be9a2aaaf2ad88cfe0f18dcefb357e9. You can [customize](https://app.ellipsis.dev/sinaptik-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->