### PR TITLE
feat: reduce generated pdf text size

### DIFF
--- a/examples/ui/backend/routes/health.py
+++ b/examples/ui/backend/routes/health.py
@@ -2,8 +2,6 @@
 Health check routes for the PandaAGI SDK API.
 """
 
-import os
-from pathlib import Path
 from fastapi import APIRouter
 
 router = APIRouter(tags=["health"])
@@ -28,17 +26,4 @@ async def root():
     Returns:
         dict: API information
     """
-    return {
-        "message": "PandaAGI SDK API",
-        "version": "1.0.0",
-        "endpoints": {
-            "POST /agent/run": "Run an agent with streaming events",
-            "DELETE /conversation/{conversation_id}": "End a conversation",
-            "POST /files/upload": "Upload a file to the workspace",
-            "GET /{conversation_id}/files/{file_path:path}": "Read a file from the workspace",
-            "GET /{conversation_id}/files/download": "Download a file from the workspace",
-            "GET /files/test-download": "Test download endpoint",
-            "GET /health": "Health check",
-            "GET /": "This endpoint",
-        },
-    }
+    return {"message": "PandaAGI SDK API", "version": "1.0.0"}

--- a/examples/ui/backend/utils/markdown_utils.py
+++ b/examples/ui/backend/utils/markdown_utils.py
@@ -136,49 +136,50 @@ async def process_markdown_to_pdf(
             <style>
                 body {{ 
                     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; 
+                    font-size: 13px;
                     line-height: 1.6; 
-                    margin: 40px; 
+                    margin: 4px; 
                     color: #333; 
                 }}
                 h1, h2, h3, h4, h5, h6 {{ 
                     color: #2c3e50; 
-                    margin-top: 24px; 
-                    margin-bottom: 16px; 
+                    margin-top: 16px; 
+                    margin-bottom: 12px; 
                 }}
                 h1 {{ 
                     border-bottom: 2px solid #eaecef; 
-                    padding-bottom: 8px; 
+                    padding-bottom: 6px; 
                 }}
                 h2 {{ 
                     border-bottom: 1px solid #eaecef; 
-                    padding-bottom: 4px; 
+                    padding-bottom: 3px; 
                 }}
                 code {{ 
                     background-color: #f6f8fa; 
-                    padding: 2px 4px; 
+                    padding: 1px 3px; 
                     border-radius: 3px; 
                     font-family: 'SFMono-Regular', Consolas, monospace; 
                 }}
                 pre {{ 
                     background-color: #f6f8fa; 
-                    padding: 16px; 
+                    padding: 12px; 
                     border-radius: 6px; 
                     overflow-x: auto; 
                 }}
                 blockquote {{ 
                     border-left: 4px solid #dfe2e5; 
-                    padding-left: 16px; 
+                    padding-left: 12px; 
                     margin-left: 0; 
                     color: #6a737d; 
                 }}
                 table {{ 
                     border-collapse: collapse; 
                     width: 100%; 
-                    margin: 16px 0; 
+                    margin: 12px 0; 
                 }}
                 th, td {{ 
                     border: 1px solid #dfe2e5; 
-                    padding: 8px 12px; 
+                    padding: 6px 8px; 
                     text-align: left; 
                 }}
                 th {{ 
@@ -196,7 +197,7 @@ async def process_markdown_to_pdf(
                     max-width: 100%; 
                     height: auto; 
                     display: block; 
-                    margin: 16px auto; 
+                    margin: 12px auto; 
                 }}
             </style>
         </head>


### PR DESCRIPTION
s size of generated pdf text
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reduce text size in generated PDFs and simplify root endpoint response in `health.py`.
> 
>   - **PDF Generation**:
>     - Reduce text size in generated PDFs by adjusting CSS styles in `markdown_utils.py`.
>     - Changes include reducing `font-size`, `margin`, and `padding` for various HTML elements.
>   - **API Response**:
>     - Simplify root endpoint response in `health.py` by removing detailed endpoint information from the returned dictionary.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=sinaptik-ai%2Fpanda-agi&utm_source=github&utm_medium=referral)<sup> for f8a3ca9df4e3ca0b603bd0b79ca57f447a8b2592. You can [customize](https://app.ellipsis.dev/sinaptik-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->