### PR TITLE
feat(GCP_BUCKET): transition to save files in gcp

### DIFF
--- a/examples/ui/backend/routes/artifacts.py
+++ b/examples/ui/backend/routes/artifacts.py
@@ -172,7 +172,7 @@ async def upload_file_to_gcs(
     upload_url = presigned_post["url"]
     fields = presigned_post["fields"].copy()
 
-    filename = f"{prefix}/{relative_path.lstrip('/')}"
+    filename = f"{prefix}/{(relative_path or 'file').lstrip('/')}"
     # This is required for `starts-with` policies.
     fields["key"] = filename
 

--- a/examples/ui/backend/routes/artifacts.py
+++ b/examples/ui/backend/routes/artifacts.py
@@ -169,6 +169,14 @@ async def upload_file_to_gcs(
     prefix: str,
     relative_path: str = None,
 ):
+    """Upload a file to GCS.
+
+    Args:
+        presigned_post (dict): GCP bucket presigned credentials
+        file_bytes (bytes): file content in bytes
+        prefix (str): Artifact ID to upload to
+        relative_path (str, optional): relative path of file Defaults to None.
+    """
     upload_url = presigned_post["url"]
     fields = presigned_post["fields"].copy()
 

--- a/examples/ui/backend/routes/artifacts.py
+++ b/examples/ui/backend/routes/artifacts.py
@@ -191,7 +191,7 @@ async def upload_file_to_gcs(
                 body = await resp.text()
                 raise Exception(f"GCS upload failed: {resp.status} {body}")
 
-            print(f"Successfully uploaded {filename} with status {resp.status}")
+            logger.info(f"Successfully uploaded {filename} with status {resp.status}")
             return resp
 
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Transition from S3 to GCS for file uploads in `artifacts.py`, updating upload logic and error handling.
> 
>   - **Behavior**:
>     - Transition from S3 to GCS for file uploads in `artifacts.py`.
>     - Replaces `upload_file_to_s3` with `upload_file_to_gcs`, updating logic for GCS-specific requirements.
>     - Updates `save_artifact` to use `upload_file_to_gcs`.
>   - **Error Handling**:
>     - Adjusts error handling in `upload_file_to_gcs` to log and raise HTTP exceptions specific to GCS.
>     - Updates logging to reflect GCS context in `upload_file_to_gcs` and `save_artifact`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=sinaptik-ai%2Fpanda-agi&utm_source=github&utm_medium=referral)<sup> for 7fe32f8d2e713857665a1aa17219a031d98d54c0. You can [customize](https://app.ellipsis.dev/sinaptik-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->