### PR TITLE
feat(auth): add multiple login providers

### DIFF
--- a/examples/ui/backend/routes/auth.py
+++ b/examples/ui/backend/routes/auth.py
@@ -48,7 +48,7 @@ async def auth_provider(
         )
 
         async with session.post(
-            f"{PANDA_AGI_SERVER_URL}/public/auth/{provider}", json=payload
+            f"{PANDA_AGI_SERVER_URL}/public/auth/{provider.lower()}", json=payload
         ) as resp:
             if resp.status != 200:
                 raise HTTPException(

--- a/examples/ui/frontend/src/app/login/page.tsx
+++ b/examples/ui/frontend/src/app/login/page.tsx
@@ -38,7 +38,7 @@ export default function Login() {
 
   const handleGitHubLogin = async () => {
     try {
-      const authUrl = await getAuthUrl('google');
+      const authUrl = await getAuthUrl('github');
       if (authUrl) {
         window.location.href = authUrl;
       }

--- a/examples/ui/frontend/src/app/login/page.tsx
+++ b/examples/ui/frontend/src/app/login/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { 
-  getGitHubAuthUrl, 
+  getAuthUrl, 
   getAccessToken, 
   isAuthRequired 
 } from "@/lib/api/auth";
@@ -38,7 +38,7 @@ export default function Login() {
 
   const handleGitHubLogin = async () => {
     try {
-      const authUrl = await getGitHubAuthUrl();
+      const authUrl = await getAuthUrl('google');
       if (authUrl) {
         window.location.href = authUrl;
       }

--- a/examples/ui/frontend/src/lib/api/auth.ts
+++ b/examples/ui/frontend/src/lib/api/auth.ts
@@ -61,17 +61,18 @@ export async function validateToken(token: string): Promise<boolean> {
 }
 
 /**
- * Gets the GitHub authentication URL from the backend
- * @returns The GitHub authentication URL if successful
+ * Gets the authentication URL from the backend for a specific provider
+ * @param provider - The authentication provider (e.g., 'github', 'google', etc.)
+ * @returns The authentication URL if successful
  */
-export async function getGitHubAuthUrl(): Promise<string | null> {
+export async function getAuthUrl(provider: string): Promise<string | null> {
   try {
     // Get the current host and construct the redirect URI
     const currentHost = window.location.origin;
     const redirectUri = `${currentHost}/authenticate`;
     
     // Pass the redirect URI as a query parameter
-    const response = await fetch(`${getServerURL()}/public/auth/github?redirect_uri=${encodeURIComponent(redirectUri)}`, {
+    const response = await fetch(`${getServerURL()}/public/auth/provider/${provider}?redirect_uri=${encodeURIComponent(redirectUri)}`, {
       credentials: 'include'
     });
     const data = await response.json();
@@ -79,19 +80,28 @@ export async function getGitHubAuthUrl(): Promise<string | null> {
     if (data && data.auth_url) {
       return data.auth_url;
     } else {
-      console.error("GitHub authentication URL not found in response:", data);
-      throw new Error("GitHub authentication URL not found in response, try again later");
+      console.error(`${provider} authentication URL not found in response:`, data);
+      throw new Error(`${provider} authentication URL not found in response, try again later`);
     }
   } catch (error) {
-    console.error("Failed to fetch GitHub authentication URL:", error);
+    console.error(`Failed to fetch ${provider} authentication URL:`, error);
     if (error instanceof Error) {
       if (error.message.includes("Failed to fetch")) {
         throw new Error("Server is not responding. Please try again in a few minutes.");
       }
       throw new Error(error.message);
     }
-    throw new Error("Failed to fetch GitHub authentication URL, try again later");
+    throw new Error(`Failed to fetch ${provider} authentication URL, try again later`);
   }
+}
+
+/**
+ * Gets the GitHub authentication URL from the backend
+ * @returns The GitHub authentication URL if successful
+ * @deprecated Use getAuthUrl('github') instead
+ */
+export async function getGitHubAuthUrl(): Promise<string | null> {
+  return getAuthUrl('github');
 }
 
 /**

--- a/examples/ui/frontend/src/lib/api/auth.ts
+++ b/examples/ui/frontend/src/lib/api/auth.ts
@@ -72,7 +72,7 @@ export async function getAuthUrl(provider: string): Promise<string | null> {
     const redirectUri = `${currentHost}/authenticate`;
     
     // Pass the redirect URI as a query parameter
-    const response = await fetch(`${getServerURL()}/public/auth/provider/${provider}?redirect_uri=${encodeURIComponent(redirectUri)}`, {
+    const response = await fetch(`${getServerURL()}/public/auth/provider/${provider.toLowerCase()}?redirect_uri=${encodeURIComponent(redirectUri)}`, {
       credentials: 'include'
     });
     const data = await response.json();


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds support for multiple authentication providers by introducing a generic auth endpoint and updating frontend logic to handle dynamic provider URLs.
> 
>   - **Backend**:
>     - Replaces `github_auth` with `auth_provider` in `auth.py`, supporting multiple providers (e.g., GitHub, Google).
>     - Validates provider and constructs dynamic authentication URL.
>   - **Frontend**:
>     - Replaces `getGitHubAuthUrl` with `getAuthUrl` in `auth.ts` for dynamic provider URLs.
>     - Updates `handleGitHubLogin` in `page.tsx` to use `getAuthUrl('github')`.
>     - Deprecates `getGitHubAuthUrl` in `auth.ts`.
>   - **Misc**:
>     - Adds `Path` import in `auth.py` for provider path parameter.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=sinaptik-ai%2Fpanda-agi&utm_source=github&utm_medium=referral)<sup> for aa20dda6bd92806dadcff088bf54b891768c9fce. You can [customize](https://app.ellipsis.dev/sinaptik-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->