### PR TITLE
fix: user message change link color in markdown

### DIFF
--- a/examples/ui/frontend/src/components/message-card.tsx
+++ b/examples/ui/frontend/src/components/message-card.tsx
@@ -14,7 +14,7 @@ const MessageCard: React.FC<MessageCardProps> = ({ message }) => {
       <div className="flex justify-end mb-2">
         <div className="bg-slate-900 text-white px-4 py-2 rounded-2xl max-w-xs lg:max-w-md">
           <div className="text-sm font-medium">
-            <MarkdownRenderer className="text-white">
+            <MarkdownRenderer className="text-white" linkColor="text-white">
               {message.content || ""}
             </MarkdownRenderer>
           </div>

--- a/examples/ui/frontend/src/components/ui/markdown-renderer.tsx
+++ b/examples/ui/frontend/src/components/ui/markdown-renderer.tsx
@@ -8,6 +8,7 @@ interface MarkdownRendererProps {
   children: string;
   baseUrl?: string | null;
   className?: string;
+  linkColor?: string;
   onPreviewClick?: (previewData: {
     url: string;
     content: string;
@@ -40,7 +41,7 @@ function truncateMiddle(text: string, maxLength: number): string {
 }
 
 // Function to manually detect and convert plain URLs to links as a fallback
-const linkifyText = (text: string | React.ReactNode, onPreviewClick?: MarkdownRendererProps["onPreviewClick"]): string | React.ReactNode => {
+const linkifyText = (text: string | React.ReactNode, onPreviewClick?: MarkdownRendererProps["onPreviewClick"], linkColor?: string): string | React.ReactNode => {
   if (typeof text !== "string") return text;
 
   // Comprehensive URL regex that properly captures full URLs
@@ -76,7 +77,7 @@ const linkifyText = (text: string | React.ReactNode, onPreviewClick?: MarkdownRe
               type: "iframe",
             })
           }
-          className="text-blue-600 hover:underline cursor-pointer bg-transparent border-none p-0 font-inherit inline break-all whitespace-pre-wrap"
+          className={`${linkColor} hover:underline cursor-pointer bg-transparent border-none p-0 font-inherit inline break-all whitespace-pre-wrap`}
         >
           {displayUrl}
         </button>
@@ -88,7 +89,7 @@ const linkifyText = (text: string | React.ReactNode, onPreviewClick?: MarkdownRe
           href={url}
           target="_blank"
           rel="noopener noreferrer"
-          className="text-blue-600 hover:underline break-all whitespace-pre-wrap"
+          className={`${linkColor} hover:underline break-all whitespace-pre-wrap`}
         >
           {displayUrl}
         </a>
@@ -107,16 +108,16 @@ const linkifyText = (text: string | React.ReactNode, onPreviewClick?: MarkdownRe
 };
 
 // Helper function to process children and linkify text
-const processChildren = (children: React.ReactNode, onPreviewClick?: MarkdownRendererProps["onPreviewClick"]): React.ReactNode => {
+const processChildren = (children: React.ReactNode, onPreviewClick?: MarkdownRendererProps["onPreviewClick"], linkColor?: string): React.ReactNode => {
   if (typeof children === "string") {
-    return linkifyText(children, onPreviewClick);
+    return linkifyText(children, onPreviewClick, linkColor);
   }
   if (Array.isArray(children)) {
     return children.map((child, index) => {
       if (typeof child === "string") {
         return (
           <React.Fragment key={index}>
-            {linkifyText(child, onPreviewClick)}
+            {linkifyText(child, onPreviewClick, linkColor)}
           </React.Fragment>
         );
       }
@@ -132,6 +133,7 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
   children,
   baseUrl = null,
   className = "", 
+  linkColor = "text-blue-600",
   onPreviewClick
 }) => {
 
@@ -160,7 +162,7 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
         components={{
           // Add manual URL detection for text nodes
           text: ({ children }) => {
-            return linkifyText(children, onPreviewClick);
+            return linkifyText(children, onPreviewClick, linkColor);
           },
           table: ({ children }) => (
             <table className="w-full border border-gray-300 border-collapse my-4">
@@ -186,22 +188,22 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
           ),
           p: ({ children }) => (
             <p className="mb-2 last:mb-0">
-              {processChildren(children, onPreviewClick)}
+              {processChildren(children, onPreviewClick, linkColor)}
             </p>
           ),
           h1: ({ children }) => (
             <h1 className="text-lg font-bold mb-2">
-              {processChildren(children, onPreviewClick)}
+              {processChildren(children, onPreviewClick, linkColor)}
             </h1>
           ),
           h2: ({ children }) => (
             <h2 className="text-base font-bold mb-2">
-              {processChildren(children, onPreviewClick)}
+              {processChildren(children, onPreviewClick, linkColor)}
             </h2>
           ),
           h3: ({ children }) => (
             <h3 className="text-sm font-bold mb-1">
-              {processChildren(children, onPreviewClick)}
+              {processChildren(children, onPreviewClick, linkColor)}
             </h3>
           ),
           code: ({ children }) => (
@@ -222,12 +224,12 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
           ),
           li: ({ children }) => (
             <li className="mb-1">
-              {processChildren(children, onPreviewClick)}
+              {processChildren(children, onPreviewClick, linkColor)}
             </li>
           ),
           blockquote: ({ children }) => (
             <blockquote className="border-l-4 border-gray-300 pl-3 italic">
-              {processChildren(children, onPreviewClick)}
+              {processChildren(children, onPreviewClick, linkColor)}
             </blockquote>
           ),
           img: ({ node, ...props }) => {
@@ -261,7 +263,7 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
                       })
                       }
                     }}
-                    className="text-blue-600 hover:underline cursor-pointer bg-transparent border-none p-0 font-inherit inline break-all whitespace-pre-wrap"
+                    className={`${linkColor} hover:underline cursor-pointer bg-transparent border-none p-0 font-inherit inline break-all whitespace-pre-wrap`}
                   >
                     {displayHref}
                   </button>
@@ -285,7 +287,7 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
                         window.open(transformedHref, '_blank');
                       }
                     }}
-                    className="text-blue-600 hover:underline cursor-pointer bg-transparent border-none p-0 font-inherit inline break-all whitespace-pre-wrap"
+                    className={`${linkColor} hover:underline cursor-pointer bg-transparent border-none p-0 font-inherit inline break-all whitespace-pre-wrap`}
                   >
                     {displayHref}
                   </button>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `linkColor` prop to `MarkdownRenderer` for customizable link colors, applied in `MessageCard` for user messages.
> 
>   - **Behavior**:
>     - Adds `linkColor` prop to `MarkdownRenderer` in `markdown-renderer.tsx` to customize link colors.
>     - Updates `MessageCard` in `message-card.tsx` to set `linkColor` to `text-white` for user messages.
>   - **Functions**:
>     - Updates `linkifyText` and `processChildren` in `markdown-renderer.tsx` to accept and apply `linkColor`.
>   - **Defaults**:
>     - Sets default `linkColor` to `text-blue-600` in `MarkdownRenderer`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=sinaptik-ai%2Fpanda-agi&utm_source=github&utm_medium=referral)<sup> for 636859f93d72b4b7442df82042c47786f124b7bf. You can [customize](https://app.ellipsis.dev/sinaptik-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->