### PR TITLE
refactor(creation_view): make creation view consistent with unified actions 

### DIFF
--- a/examples/ui/backend/routes/artifacts.py
+++ b/examples/ui/backend/routes/artifacts.py
@@ -239,7 +239,7 @@ async def save_artifact(
 
                 # Store the artifact ID for potential cleanup
                 artifact = response.get("artifact")
-                artifact_id = artifact.get("id")
+                artifact_id = artifact.get("id") if artifact else None
 
         files_generator = ArtifactsService.get_files_for_artifact(
             payload.type, payload.filepath, conversation_id, artifact_id

--- a/examples/ui/backend/routes/artifacts.py
+++ b/examples/ui/backend/routes/artifacts.py
@@ -238,7 +238,8 @@ async def save_artifact(
                     )
 
                 # Store the artifact ID for potential cleanup
-                artifact_id = response.get("artifact_id")
+                artifact = response.get("artifact")
+                artifact_id = artifact.get("id")
 
         files_generator = ArtifactsService.get_files_for_artifact(
             payload.type, payload.filepath, conversation_id, artifact_id
@@ -249,7 +250,7 @@ async def save_artifact(
                 response["upload_credentials"], file_bytes, artifact_id, relative_path
             )
 
-        return {"detail": "Creations saved successfully"}
+        return {"detail": "Creations saved successfully", "artifact": artifact}
     except HTTPException as e:
         raise e
     except ValueError as e:

--- a/examples/ui/frontend/src/components/artifact-actions.tsx
+++ b/examples/ui/frontend/src/components/artifact-actions.tsx
@@ -20,7 +20,6 @@ interface ArtifactActionsProps {
   onClose?: () => void;
   showShare?: boolean;
   showDelete?: boolean;
-  className?: string;
 }
 
 const ArtifactActions: React.FC<ArtifactActionsProps> = ({
@@ -30,7 +29,6 @@ const ArtifactActions: React.FC<ArtifactActionsProps> = ({
   onClose,
   showShare = true,
   showDelete = true,
-  className = "",
 }) => {
   const [isUpdating, setIsUpdating] = useState(false);
   

--- a/examples/ui/frontend/src/components/artifact-actions.tsx
+++ b/examples/ui/frontend/src/components/artifact-actions.tsx
@@ -1,0 +1,181 @@
+import React, { useState } from "react";
+import { Share2, MoreVertical, Trash2 } from "lucide-react";
+import { toast } from "react-hot-toast";
+import { useModalState } from "@/hooks/useModalState";
+import ShareModal from "./share-modal";
+import DeleteConfirmationDialog from "./delete-confirmation-dialog";
+import { ArtifactResponse } from "@/lib/api/artifacts";
+import { ArtifactData } from "@/types/artifact";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+interface ArtifactActionsProps {
+  artifact: ArtifactData;
+  onArtifactUpdated?: (artifact: ArtifactData) => void;
+  onArtifactDeleted?: (artifactId: string) => void;
+  onClose?: () => void;
+  showShare?: boolean;
+  showDelete?: boolean;
+  className?: string;
+}
+
+const ArtifactActions: React.FC<ArtifactActionsProps> = ({
+  artifact,
+  onArtifactUpdated,
+  onArtifactDeleted,
+  onClose,
+  showShare = true,
+  showDelete = true,
+  className = "",
+}) => {
+  const [isUpdating, setIsUpdating] = useState(false);
+  
+  // Modal state management
+  const shareModal = useModalState();
+  const deleteModal = useModalState();
+
+  // Handle share
+  const handleShare = () => {
+    shareModal.open();
+  };
+
+  // Handle delete
+  const handleDelete = () => {
+    deleteModal.open();
+  };
+
+  const handleDeleteConfirm = async () => {
+    if (!artifact) {
+      toast.error("No artifact to delete");
+      return;
+    }
+    
+    deleteModal.setLoading(true);
+    try {
+      // Import the deleteArtifact function
+      const { deleteArtifact } = await import("@/lib/api/artifacts");
+      await deleteArtifact(artifact.id);
+      
+      toast.success('Artifact deleted successfully');
+      deleteModal.close();
+      
+      if (onArtifactDeleted) {
+        onArtifactDeleted(artifact.id);
+      }
+      
+      if (onClose) {
+        onClose();
+      }
+    } catch (error) {
+      console.error('Failed to delete artifact:', error);
+      toast.error('Failed to delete artifact');
+    } finally {
+      deleteModal.setLoading(false);
+    }
+  };
+
+  // Handle artifact privacy toggle
+  const handleTogglePublic = async (artifactToUpdate: ArtifactData) => {
+    if (!artifactToUpdate) return;
+    
+    setIsUpdating(true);
+    try {
+      // Import the updateArtifact function
+      const { updateArtifact } = await import("@/lib/api/artifacts");
+      const updatedArtifact = await updateArtifact(artifactToUpdate.id, { 
+        is_public: !artifactToUpdate.is_public 
+      });
+      
+      const newArtifactData: ArtifactData = {
+        ...artifactToUpdate,
+        is_public: updatedArtifact.is_public,
+      };
+      
+      if (onArtifactUpdated) {
+        onArtifactUpdated(newArtifactData);
+      }
+      
+      toast.success(`Creation made ${updatedArtifact.is_public ? 'public' : 'private'} successfully!`);
+    } catch (error) {
+      console.error('Failed to update privacy setting:', error);
+      toast.error('Failed to update privacy setting');
+    } finally {
+      setIsUpdating(false);
+    }
+  };
+
+  // Create header actions
+  const headerActions = (
+    <>
+      {/* Share button */}
+      {showShare && (
+        <button
+          onClick={handleShare}
+          className="h-8 w-8 rounded-md hover:bg-accent transition-colors flex items-center justify-center cursor-pointer"
+          title="Share"
+        >
+          <Share2 className="h-4 w-4 text-muted-foreground" />
+        </button>
+      )}
+      {/* More options dropdown */}
+      {showDelete && (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button
+              className="h-8 w-8 rounded-md hover:bg-accent transition-colors flex items-center justify-center cursor-pointer"
+              title="More options"
+            >
+              <MoreVertical className="h-4 w-4 text-muted-foreground" />
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-48">
+            <DropdownMenuItem
+              onClick={handleDelete}
+              className="text-destructive focus:text-destructive cursor-pointer"
+            >
+              <Trash2 className="h-4 w-4 mr-2" />
+              Delete
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )}
+    </>
+  );
+
+  return (
+    <>
+      
+        {headerActions}
+      
+      {/* Share Modal */}
+      {shareModal.isOpen && (
+        <ShareModal
+          isOpen={shareModal.isOpen}
+          onClose={shareModal.close}
+          artifact={artifact as ArtifactResponse}
+          onTogglePublic={handleTogglePublic}
+          isUpdating={isUpdating}
+        />
+      )}
+      
+      {/* Delete Confirmation Dialog */}
+      {deleteModal.isOpen && (
+        <DeleteConfirmationDialog
+          isOpen={deleteModal.isOpen}
+          onClose={deleteModal.close}
+          onConfirm={handleDeleteConfirm}
+          title="Delete Artifact"
+          description="Are you sure you want to delete this artifact? This action cannot be undone."
+          itemName={artifact?.name}
+          isLoading={deleteModal.isLoading}
+        />
+      )}
+    </>
+  );
+};
+
+export default ArtifactActions; 

--- a/examples/ui/frontend/src/components/content-sidebar.tsx
+++ b/examples/ui/frontend/src/components/content-sidebar.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { Download, FileImage, File } from "lucide-react";
+import { Download, FileImage, File, Share2, MoreVertical, Trash2 } from "lucide-react";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { vscDarkPlus } from "react-syntax-highlighter/dist/esm/styles/prism";
 import MarkdownRenderer from "./ui/markdown-renderer";
@@ -17,6 +17,14 @@ import {
   isExcelFile,
   validateContentType,
 } from "@/lib/utils";
+import DeleteConfirmationDialog from "./delete-confirmation-dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { useModalState } from "@/hooks/useModalState";
 
 export interface PreviewData {
   title?: string;
@@ -62,6 +70,20 @@ const ContentSidebar: React.FC<ContentSidebarProps> = ({
   );
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // Modal state management
+  const shareModal = useModalState();
+  const deleteModal = useModalState();
+  const [isUpdating, setIsUpdating] = useState(false);
+
+  // Clean up modals on component unmount
+  useEffect(() => {
+    return () => {
+      shareModal.close();
+      deleteModal.close();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Fetch file content when previewData changes
   useEffect(() => {
@@ -604,6 +626,53 @@ const ContentSidebar: React.FC<ContentSidebarProps> = ({
     }
   };
 
+  // Handle share
+  const handleShare = () => {
+    shareModal.open();
+  };
+
+  // Handle delete
+  const handleDelete = () => {
+    deleteModal.open();
+  };
+
+  const handleDeleteConfirm = async () => {
+    if (!normalizedFilename || !conversationId) {
+      toast.error("Missing file information");
+      return;
+    }
+    
+    deleteModal.setLoading(true);
+    try {
+      // For content sidebar, we'll close the sidebar instead of deleting from server
+      // since the file might not be saved as an artifact yet
+      toast.success('Content closed');
+      deleteModal.close();
+      onClose();
+    } catch (error) {
+      console.error('Failed to close content:', error);
+      toast.error('Failed to close content');
+    } finally {
+      deleteModal.setLoading(false);
+    }
+  };
+
+  // Handle toggle public (for share modal)
+  const handleTogglePublic = async (artifact: any) => {
+    // This is a placeholder since content sidebar doesn't have artifacts yet
+    // The actual implementation would depend on your backend API
+    setIsUpdating(true);
+    try {
+      // Placeholder - you would implement actual API call here
+      toast.success('Privacy setting updated');
+    } catch (error) {
+      console.error('Failed to update privacy setting:', error);
+      toast.error('Failed to update privacy setting');
+    } finally {
+      setIsUpdating(false);
+    }
+  };
+
   // Create header actions
   const headerActions = (
     <>
@@ -630,6 +699,34 @@ const ContentSidebar: React.FC<ContentSidebarProps> = ({
             <Download className="h-4 w-4 text-muted-foreground" />
           </button>
         )}
+      {/* Share button */}
+      <button
+        onClick={handleShare}
+        className="h-8 w-8 rounded-md hover:bg-accent transition-colors flex items-center justify-center cursor-pointer"
+        title="Share"
+      >
+        <Share2 className="h-4 w-4 text-muted-foreground" />
+      </button>
+      {/* More options dropdown */}
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            className="h-8 w-8 rounded-md hover:bg-accent transition-colors flex items-center justify-center cursor-pointer"
+            title="More options"
+          >
+            <MoreVertical className="h-4 w-4 text-muted-foreground" />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-48">
+          <DropdownMenuItem
+            onClick={handleDelete}
+            className="text-destructive focus:text-destructive cursor-pointer"
+          >
+            <Trash2 className="h-4 w-4 mr-2" />
+            Close
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
     </>
   );
 
@@ -678,6 +775,67 @@ const ContentSidebar: React.FC<ContentSidebarProps> = ({
           renderContent()
         )}
       </ResizableSidebar>
+      
+      {/* Share Modal - Custom for content sidebar */}
+      {shareModal.isOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center">
+          <div className="fixed inset-0 bg-black/50" onClick={shareModal.close} />
+          <div className="relative bg-background rounded-lg shadow-lg max-w-md w-full mx-4 p-6">
+            <div className="flex items-center justify-between mb-4">
+              <h2 className="text-lg font-semibold">Share content</h2>
+              <button
+                onClick={shareModal.close}
+                className="text-muted-foreground hover:text-foreground"
+              >
+                ✕
+              </button>
+            </div>
+            <div className="space-y-4">
+              <div className="flex items-center gap-3 p-3 bg-muted/20 rounded-md">
+                <div className="w-10 h-10 bg-muted rounded-lg flex items-center justify-center">
+                  <Share2 className="h-5 w-5 text-muted-foreground" />
+                </div>
+                <div>
+                  <p className="text-sm font-medium">Content not saved yet</p>
+                  <p className="text-xs text-muted-foreground">
+                    Save this content as an artifact to share it with others.
+                  </p>
+                </div>
+              </div>
+              <div className="flex justify-end space-x-2">
+                <button
+                  onClick={shareModal.close}
+                  className="px-4 py-2 text-sm border rounded-md hover:bg-accent"
+                >
+                  Cancel
+                </button>
+                <button
+                  onClick={() => {
+                    shareModal.close();
+                    toast("Use the save button to save this content as an artifact");
+                  }}
+                  className="px-4 py-2 text-sm bg-primary text-primary-foreground rounded-md hover:bg-primary/90"
+                >
+                  Save First
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+      
+      {/* Delete Confirmation Dialog */}
+      {deleteModal.isOpen && (
+        <DeleteConfirmationDialog
+          isOpen={deleteModal.isOpen}
+          onClose={deleteModal.close}
+          onConfirm={handleDeleteConfirm}
+          title="Close Content"
+          description="Are you sure you want to close this content? This action cannot be undone."
+          itemName={previewData?.title || normalizedFilename}
+          isLoading={deleteModal.isLoading}
+        />
+      )}
     </>
   );
 };

--- a/examples/ui/frontend/src/components/content-sidebar.tsx
+++ b/examples/ui/frontend/src/components/content-sidebar.tsx
@@ -815,64 +815,15 @@ const ContentSidebar: React.FC<ContentSidebarProps> = ({
         )}
       </ResizableSidebar>
       
-      {/* Share Modal - Show actual ShareModal when saved, custom modal when not saved */}
-      {shareModal.isOpen && (
-        <>
-          {isSaved && savedArtifact ? (
-            <ShareModal
-              isOpen={shareModal.isOpen}
-              onClose={shareModal.close}
-              artifact={savedArtifact}
-              onTogglePublic={handleTogglePublic}
-              isUpdating={isUpdating}
-            />
-          ) : (
-            <div className="fixed inset-0 z-50 flex items-center justify-center">
-              <div className="fixed inset-0 bg-black/50" onClick={shareModal.close} />
-              <div className="relative bg-background rounded-lg shadow-lg max-w-md w-full mx-4 p-6">
-                <div className="flex items-center justify-between mb-4">
-                  <h2 className="text-lg font-semibold">Share content</h2>
-                  <button
-                    onClick={shareModal.close}
-                    className="text-muted-foreground hover:text-foreground"
-                  >
-                    ✕
-                  </button>
-                </div>
-                <div className="space-y-4">
-                  <div className="flex items-center gap-3 p-3 bg-muted/20 rounded-md">
-                    <div className="w-10 h-10 bg-muted rounded-lg flex items-center justify-center">
-                      <Share2 className="h-5 w-5 text-muted-foreground" />
-                    </div>
-                    <div>
-                      <p className="text-sm font-medium">Content not saved yet</p>
-                      <p className="text-xs text-muted-foreground">
-                        Save this content as an artifact to share it with others.
-                      </p>
-                    </div>
-                  </div>
-                  <div className="flex justify-end space-x-2">
-                    <button
-                      onClick={shareModal.close}
-                      className="px-4 py-2 text-sm border rounded-md hover:bg-accent"
-                    >
-                      Cancel
-                    </button>
-                    <button
-                      onClick={() => {
-                        shareModal.close();
-                        toast("Use the save button to save this content as an artifact");
-                      }}
-                      className="px-4 py-2 text-sm bg-primary text-primary-foreground rounded-md hover:bg-primary/90"
-                    >
-                      Save First
-                    </button>
-                  </div>
-                </div>
-              </div>
-            </div>
-          )}
-        </>
+      {/* Share Modal - Only show when content is saved */}
+      {shareModal.isOpen && isSaved && savedArtifact && (
+        <ShareModal
+          isOpen={shareModal.isOpen}
+          onClose={shareModal.close}
+          artifact={savedArtifact}
+          onTogglePublic={handleTogglePublic}
+          isUpdating={isUpdating}
+        />
       )}
       
       {/* Delete Confirmation Dialog */}

--- a/examples/ui/frontend/src/components/content-sidebar.tsx
+++ b/examples/ui/frontend/src/components/content-sidebar.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/lib/utils";
 import ArtifactActions from "./artifact-actions";
 import { ArtifactData } from "@/types/artifact";
+import { useFullScreenToggle } from "@/hooks/useFullScreenToggle";
 
 export interface PreviewData {
   title?: string;
@@ -68,6 +69,12 @@ const ContentSidebar: React.FC<ContentSidebarProps> = ({
   // Saved state management
   const [isSaved, setIsSaved] = useState(false);
   const [savedArtifact, setSavedArtifact] = useState<ArtifactData | null>(null);
+  
+  // Custom hooks for cleaner state management
+  const fullScreen = useFullScreenToggle({ 
+    initialWidth: width, 
+    onResize 
+  });
 
   // Reset saved state when sidebar closes
   useEffect(() => {
@@ -712,6 +719,9 @@ const ContentSidebar: React.FC<ContentSidebarProps> = ({
         onResize={onResize}
         loading={isLoading}
         error={error}
+        enableFullMode={true}
+        isFullMode={fullScreen.isFullMode}
+        onToggleFullMode={fullScreen.toggleFullMode}
         className={isFullHeightContent() ? "[&>div:last-child]:p-0" : ""}
       >
         {isFullHeightContent() ? (

--- a/examples/ui/frontend/src/components/save-artifact-button.tsx
+++ b/examples/ui/frontend/src/components/save-artifact-button.tsx
@@ -12,7 +12,7 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { saveArtifact } from "@/lib/api/artifacts";
+import { saveArtifact, ArtifactResponse } from "@/lib/api/artifacts";
 import { toast } from "react-hot-toast";
 
 interface SaveArtifactButtonProps {
@@ -24,7 +24,7 @@ interface SaveArtifactButtonProps {
     content?: string;
     type?: string;
   };
-  onSave?: (artifactData: any) => void;
+  onSave?: (artifactData: { artifact: ArtifactResponse, detail: string }) => void;
 }
 
 const SaveArtifactButton: React.FC<SaveArtifactButtonProps> = ({

--- a/examples/ui/frontend/src/components/save-artifact-button.tsx
+++ b/examples/ui/frontend/src/components/save-artifact-button.tsx
@@ -24,11 +24,13 @@ interface SaveArtifactButtonProps {
     content?: string;
     type?: string;
   };
+  onSave?: (artifactData: any) => void;
 }
 
 const SaveArtifactButton: React.FC<SaveArtifactButtonProps> = ({
   conversationId,
   previewData,
+  onSave,
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [artifactName, setArtifactName] = useState("");
@@ -47,7 +49,7 @@ const SaveArtifactButton: React.FC<SaveArtifactButtonProps> = ({
 
     setIsLoading(true);
     try {
-      await saveArtifact(conversationId, {
+      const savedArtifact = await saveArtifact(conversationId, {
         type: previewData?.type || "text",
         name: artifactName.trim(),
         filepath: previewData?.url || previewData?.filename || ""
@@ -55,6 +57,11 @@ const SaveArtifactButton: React.FC<SaveArtifactButtonProps> = ({
       toast.success("Creation saved successfully!");
       setIsOpen(false);
       setArtifactName("");
+      
+      // Call the onSave callback with the saved artifact data
+      if (onSave) {
+        onSave(savedArtifact);
+      }
     } catch (error) {
       console.error("Save error:", error);
       if (error instanceof Error) {

--- a/examples/ui/frontend/src/lib/api/artifacts.ts
+++ b/examples/ui/frontend/src/lib/api/artifacts.ts
@@ -17,7 +17,12 @@ export interface ArtifactResponse {
     is_public: boolean;
 }
 
-export const saveArtifact = async (conversationId: string, payload: ArtifactPayload): Promise<ArtifactResponse> => {
+export interface ArtifactResponseWithDetail {
+    artifact: ArtifactResponse;
+    detail: string;
+}
+
+export const saveArtifact = async (conversationId: string, payload: ArtifactPayload): Promise<ArtifactResponseWithDetail> => {
     const url = getBackendServerURL(`/artifacts/${conversationId}/save`);
     const options = await getApiOptions();
     


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor artifact creation view for consistency with unified actions, updating backend responses and frontend components.
> 
>   - **Backend**:
>     - In `artifacts.py`, `save_artifact()` now returns `artifact` object with `id` for consistency.
>   - **Frontend Components**:
>     - New `ArtifactActions` component in `artifact-actions.tsx` for handling share, delete, and privacy toggle actions.
>     - `ArtifactViewer` and `ContentSidebar` components updated to use `ArtifactActions` for consistent action handling.
>     - `SaveArtifactButton` now accepts `onSave` callback to handle post-save actions.
>   - **API**:
>     - `saveArtifact()` in `artifacts.ts` returns `ArtifactResponseWithDetail` for detailed response handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=sinaptik-ai%2Fpanda-agi&utm_source=github&utm_medium=referral)<sup> for 3622887befc75b90a606e13ccc32bd77e5e3a6e9. You can [customize](https://app.ellipsis.dev/sinaptik-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->