### PR TITLE
fix: force flag to false

### DIFF
--- a/examples/ui/backend/services/artifacts.py
+++ b/examples/ui/backend/services/artifacts.py
@@ -53,7 +53,7 @@ class ArtifactsService:
 
         try:
             # Get the file content to analyze
-            env = await get_env({"conversation_id": conversation_id}, force_new=True)
+            env = await get_env({"conversation_id": conversation_id})
             content_bytes, _ = await FilesService.get_file_from_env(filepath, env)
             file_content = content_bytes.decode("utf-8", errors="ignore")
 
@@ -354,6 +354,8 @@ Suggested name:"""
         # Step 4 & 5: Return all referenced files with window.location.origin replacement
         for file_path in referenced_files:
             try:
+
+                logger.info(f"Getting file {file_path}")
                 content_bytes, mime_type = await FilesService.get_file_from_env(
                     file_path, env
                 )


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Removes `force_new=True` flag in `suggest_artifact_name()` and adds logging in `get_files_for_iframe()` in `artifacts.py`.
> 
>   - **Behavior**:
>     - Removes `force_new=True` flag in `suggest_artifact_name()` in `artifacts.py` when calling `get_env`.
>     - Adds logging statement in `get_files_for_iframe()` in `artifacts.py` to log file retrieval attempts.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=sinaptik-ai%2Fpanda-agi&utm_source=github&utm_medium=referral)<sup> for c68d610abb97f04043bd4b2a47230970b3e850b7. You can [customize](https://app.ellipsis.dev/sinaptik-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->