### PR TITLE
fix: ui suggestion to stop api call if user types something

### DIFF
--- a/examples/ui/frontend/src/lib/api/artifacts.ts
+++ b/examples/ui/frontend/src/lib/api/artifacts.ts
@@ -31,7 +31,7 @@ export interface ArtifactResponseWithDetail {
     detail: string;
 }
 
-export const suggestArtifactName = async (conversationId: string, payload: NameSuggestionRequest): Promise<NameSuggestionResponse> => {
+export const suggestArtifactName = async (conversationId: string, payload: NameSuggestionRequest, signal?: AbortSignal): Promise<NameSuggestionResponse> => {
     const url = getBackendServerURL(`/artifacts/${conversationId}/suggest-name`);
     const options = await getApiOptions();
     
@@ -39,6 +39,7 @@ export const suggestArtifactName = async (conversationId: string, payload: NameS
         method: 'POST',
         ...options,
         body: JSON.stringify(payload),
+        signal,
     });
     
     if (!response.ok) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Introduces request cancellation for name suggestions in `save-artifact-button.tsx` using `AbortController` to stop API calls when user types.
> 
>   - **Behavior**:
>     - Adds `abortControllerRef` in `save-artifact-button.tsx` to manage API call cancellations.
>     - Cancels ongoing name suggestion API calls if the user starts typing in `handleInputChange()`.
>     - Updates `suggestArtifactName()` in `artifacts.ts` to accept an `AbortSignal` for request cancellation.
>   - **Functions**:
>     - Modifies `suggestArtifactName()` to include `signal` parameter for fetch request.
>     - Adds `handleInputChange()` to manage input changes and cancel suggestions.
>   - **Misc**:
>     - Refactors input change logic to use `handleInputChange()` in `save-artifact-button.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=sinaptik-ai%2Fpanda-agi&utm_source=github&utm_medium=referral)<sup> for a8cd4c02c7ad6fbd8c6d0681df7096cc33e2e8c3. You can [customize](https://app.ellipsis.dev/sinaptik-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->