### PR TITLE
fix: table node not found error in markdown

### DIFF
--- a/examples/ui/frontend/src/components/artifact-viewer.tsx
+++ b/examples/ui/frontend/src/components/artifact-viewer.tsx
@@ -28,6 +28,7 @@ import rehypeStringify from "rehype-stringify"
 // HTML → Markdown
 import rehypeParse from "rehype-parse"
 import rehypeRemark from "rehype-remark"
+import remarkGfm from "remark-gfm";
 import remarkStringify from "remark-stringify"
 
 // Markdown → HTML with empty line preservation
@@ -43,6 +44,7 @@ export async function markdownToHtml(markdown: string): Promise<string> {
   
   const file = await unified()
     .use(remarkParse)
+    .use(remarkGfm)
     .use(remarkRehype, { allowDangerousHtml: true })
     .use(rehypeStringify, { allowDangerousHtml: true })
     .process(processedMarkdown);
@@ -67,6 +69,7 @@ export async function htmlToMarkdown(html: string): Promise<string> {
   const file = await unified()
     .use(rehypeParse, { fragment: true })
     .use(rehypeRemark)
+    .use(remarkGfm)
     .use(remarkStringify)
     .process(processedHtml);
   


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `remark-gfm` to support GitHub Flavored Markdown in `markdownToHtml()` and `htmlToMarkdown()` functions in `artifact-viewer.tsx`.
> 
>   - **Behavior**:
>     - Adds `remark-gfm` to `markdownToHtml()` and `htmlToMarkdown()` functions in `artifact-viewer.tsx` to support GitHub Flavored Markdown (GFM).
>     - Handles tables and other GFM-specific syntax in markdown files.
>   - **Misc**:
>     - No changes to existing logic or other parts of the codebase.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=sinaptik-ai%2Fpanda-agi&utm_source=github&utm_medium=referral)<sup> for f7eaa43336ae5f108c1e4160c32f0ddd41708a45. You can [customize](https://app.ellipsis.dev/sinaptik-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->