### PR TITLE
fix: limit csv read lines to max 20 rows and pass header in query

### DIFF
--- a/examples/ui/backend/models/agent.py
+++ b/examples/ui/backend/models/agent.py
@@ -14,6 +14,7 @@ class AgentQuery(BaseModel):
 
     query: str
     conversation_id: Optional[str] = None
+    file_names: Optional[List[str]] = None
     timeout: Optional[int] = None
 
 

--- a/examples/ui/backend/routes/agent.py
+++ b/examples/ui/backend/routes/agent.py
@@ -34,7 +34,12 @@ async def run_agent(query_data: AgentQuery, request: Request):
         api_key = getattr(request.state, "api_key", None)
 
         return StreamingResponse(
-            event_stream(query_data.query, query_data.conversation_id, api_key),
+            event_stream(
+                query_data.query,
+                query_data.conversation_id,
+                query_data.file_names,
+                api_key,
+            ),
             media_type="text/event-stream",
             headers={
                 "Cache-Control": "no-cache",

--- a/examples/ui/backend/services/agent.py
+++ b/examples/ui/backend/services/agent.py
@@ -82,13 +82,14 @@ async def event_stream(
 
         # if there is only one file, read it and add the first 5 rows to the query
         if file_names and len(file_names) == 1 and file_names[0].endswith(".csv"):
-            result = await agent.environment.read_file(path=file_names[0])
-            if result["status"] == "success":
-                lines = result["content"].splitlines(keepends=True)
-                content = "".join(lines[0:5])
-                query = (
-                    f"{query}\n\nHere are the first 5 rows of the file\n\n: {content}"
-                )
+            try:
+                result = await agent.environment.read_file(path=file_names[0])
+                if result["status"] == "success":
+                    lines = result["content"].splitlines(keepends=True)
+                    content = "".join(lines[0:5])
+                    query = f"{query}\n\nHere are the first 5 rows of the file\n\n: {content}"
+            except Exception as e:
+                logger.error("error reading file: ", e)
 
         # Send conversation ID as first event
         conversation_event = {

--- a/examples/ui/frontend/src/components/chatbox.tsx
+++ b/examples/ui/frontend/src/components/chatbox.tsx
@@ -41,6 +41,7 @@ import toast from "react-hot-toast";
 interface RequestBody {
   query: string;
   conversation_id?: string;
+  file_names?: string[];
 }
 
 export interface ChatBoxRef {
@@ -571,6 +572,10 @@ const ChatBox = forwardRef<ChatBoxRef, ChatBoxProps>(
         // Include conversation_id if we have one (for follow-up messages)
         if (conversationId) {
           requestBody.conversation_id = conversationId;
+        }
+
+        if (pendingFiles.length > 0) {
+          requestBody.file_names = pendingFiles.map((file) => file.filename);
         }
 
         const apiHeaders = await getApiHeaders();

--- a/panda_agi/tools/file_system.py
+++ b/panda_agi/tools/file_system.py
@@ -36,6 +36,12 @@ class FileReadHandler(ToolHandler):
         # await self.add_event(EventType.FILE_READ, params)
         params["start_line"] = int(params.get("start_line", 1))
         params["end_line"] = int(params.get("end_line", 1))
+
+        file = params.get("file", None)
+        # check if extension is csv set end_line
+        if file and file.endswith(".csv"):
+            params["end_line"] = min(params["end_line"], 20)
+
         result = await file_read(self.environment, **params)
         return ToolResult(
             success=result.get("status") == "success",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhance CSV handling by limiting read lines, appending file content to queries, and passing file names in requests.
> 
>   - **Behavior**:
>     - Limit CSV file read to 20 lines in `FileReadHandler` in `file_system.py`.
>     - Append first 5 lines of a single CSV file to query in `event_stream()` in `agent.py`.
>   - **Models**:
>     - Add `file_names` field to `AgentQuery` in `agent.py`.
>   - **Routes**:
>     - Pass `file_names` to `event_stream()` in `run_agent()` in `agent.py`.
>   - **Frontend**:
>     - Include `file_names` in `RequestBody` in `chatbox.tsx`.
>     - Map `pendingFiles` to `file_names` in `sendMessage()` in `chatbox.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=sinaptik-ai%2Fpanda-agi&utm_source=github&utm_medium=referral)<sup> for 80f745d0f04d0842aec249a0ee16e8db1ad90b61. You can [customize](https://app.ellipsis.dev/sinaptik-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->