### PR TITLE
fix(dashboard): dashboard stuck in chat ui

### DIFF
--- a/examples/ui/backend/pxml/js/csv-loader.js
+++ b/examples/ui/backend/pxml/js/csv-loader.js
@@ -100,10 +100,16 @@ class CSVLoader {
             // Use the actual file path from PXML, not hardcoded 'dataset.csv'
             // Extract just the filename from the full path
             const fileName = filePath.split('/').pop();
-            
+
             // Construct the correct URL for the CSV file
             // URL pattern: /creations/{artifactId}/{fileName}
-            const fileUrl = `/creations/${artifactId}/${fileName}`;
+            // By default it picks the base path browser or when iframe is used
+            let fileUrl = "";
+            if (artifactId !== "default") {
+                fileUrl = `/creations/${artifactId}/${fileName}`;
+            } else {
+                fileUrl = filePath;
+            }
             
             const response = await fetch(fileUrl);
             

--- a/examples/ui/backend/routes/files.py
+++ b/examples/ui/backend/routes/files.py
@@ -364,12 +364,8 @@ async def read_file(
         # Check if it's a PXML file and compile it (unless raw mode is requested)
         if file_path.lower().endswith((".pxml")) and not raw:
             content_bytes = content_bytes.decode("utf-8")
-            # Extract artifact ID from the conversation_id for now
-            # In the future, this should be passed as a parameter
-            artifact_id = conversation_id
-            html_content = await PXMLService.compile_pxml(
-                content_bytes, local_env, artifact_id
-            )
+
+            html_content = await PXMLService.compile_pxml(content_bytes, local_env)
             return Response(content=html_content, media_type="text/html")
 
         # Check if it's a markdown file and raw mode is not requested

--- a/examples/ui/frontend/src/components/artifact-viewer.tsx
+++ b/examples/ui/frontend/src/components/artifact-viewer.tsx
@@ -472,6 +472,7 @@ const ArtifactViewer: React.FC<ArtifactViewerProps> = ({
               title={artifact.name}
               sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-downloads"
             />
+            
           </div>
         );
       default:

--- a/examples/ui/frontend/src/components/content-sidebar.tsx
+++ b/examples/ui/frontend/src/components/content-sidebar.tsx
@@ -500,7 +500,7 @@ const ContentSidebar: React.FC<ContentSidebarProps> = ({
           src={url}
           className="w-full h-full"
           title={title}
-          sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
+          sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-downloads"
         />
       </div>
     );


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix dashboard chat UI issue by adjusting file URL handling and iframe sandbox attributes.
> 
>   - **Behavior**:
>     - In `csv-loader.js`, modify URL construction for CSV files to use `filePath` directly if `artifactId` is "default".
>     - In `files.py`, remove `artifact_id` parameter from `PXMLService.compile_pxml()` call in `read_file()`.
>   - **UI Components**:
>     - In `artifact-viewer.tsx` and `content-sidebar.tsx`, add `allow-downloads` to iframe `sandbox` attributes to enable downloads.
>   - **Misc**:
>     - Minor whitespace change in `artifact-viewer.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=sinaptik-ai%2Fpanda-agi&utm_source=github&utm_medium=referral)<sup> for 8465e5b6400600c1feae9661b82ab53aa62d62f8. You can [customize](https://app.ellipsis.dev/sinaptik-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->