### PR TITLE
fix: missing column name in the csv

### DIFF
--- a/examples/ui/backend/pxml/csv_processor.py
+++ b/examples/ui/backend/pxml/csv_processor.py
@@ -351,7 +351,7 @@ class CSVProcessor:
         try:
             # Use StringIO to convert string content to file-like object for pandas
             csv_io = StringIO(csv_content)
-            self.data = pd.read_csv(csv_io)
+            self.data = pd.read_csv(csv_io, on_bad_lines="skip")
             self.headers = list(self.data.columns)
             self._create_column_mappings()
             return True


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> In `csv_processor.py`, `load_csv_from_string` now skips malformed lines when reading CSV content using `pd.read_csv` with `on_bad_lines="skip"`.
> 
>   - **Behavior**:
>     - In `csv_processor.py`, `load_csv_from_string` now uses `pd.read_csv` with `on_bad_lines="skip"` to skip malformed lines in CSV content.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=sinaptik-ai%2Fpanda-agi&utm_source=github&utm_medium=referral)<sup> for 308c42dc92b0365af911e1d0753247b17e52491c. You can [customize](https://app.ellipsis.dev/sinaptik-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->