### PR TITLE
fix: raise compilation error if failed instead of fallback

### DIFF
--- a/examples/ui/backend/routes/artifacts.py
+++ b/examples/ui/backend/routes/artifacts.py
@@ -453,7 +453,7 @@ async def save_artifact(
         if artifact_id:
             await cleanup_artifact(artifact_id, api_key)
         logger.error(f"Error saving creations: {traceback.format_exc()}")
-        raise HTTPException(status_code=500, detail="internal server error")
+        raise HTTPException(status_code=500, detail="Failed to save creations")
 
 
 @router.get("/", response_model=ArtifactsListResponse)
@@ -584,6 +584,10 @@ async def serve_artifact_file(
                     )
                     if html_response:
                         return html_response
+                    else:
+                        raise HTTPException(
+                            status_code=500, detail="Failed to convert PXML to HTML"
+                        )
 
                 # Determine MIME type for non-markdown files
                 mime_type, _ = mimetypes.guess_type(file_path)

--- a/examples/ui/backend/services/artifacts.py
+++ b/examples/ui/backend/services/artifacts.py
@@ -467,7 +467,7 @@ Suggested name:"""
                 yield csv_content_bytes, csv_file_path
 
             if csv_file_count == 0:
-                raise ValueError(f"Csv file path not found {filepath}")
+                raise ValueError(f"CSV file path not found {filepath}")
 
             # Also yield the PXML file itself
             yield pxml_content.encode("utf-8"), filepath

--- a/examples/ui/backend/services/artifacts.py
+++ b/examples/ui/backend/services/artifacts.py
@@ -456,13 +456,18 @@ Suggested name:"""
             )
 
             # Get CSV files using the PXMLService method
+            csv_file_count = 0
             async for (
                 csv_content_bytes,
                 csv_file_path,
             ) in PXMLService.get_csv_files_for_pxml(pxml_content, env):
                 logger.info(f"Uploading PXML CSV file path: {csv_file_path}")
                 # Yield the CSV file content with its filepath
+                csv_file_count += 1
                 yield csv_content_bytes, csv_file_path
+
+            if csv_file_count == 0:
+                raise ValueError(f"Csv file path not found {filepath}")
 
             # Also yield the PXML file itself
             yield pxml_content.encode("utf-8"), filepath
@@ -470,12 +475,4 @@ Suggested name:"""
         except Exception as e:
             logger.error(f"Error getting files for PXML {filepath}: {e}")
             logger.error(f"Traceback: {traceback.format_exc()}")
-            # If there's an error, still try to yield the PXML file itself
-            try:
-                pxml_content_bytes, _ = await ArtifactsService.get_file_for_artifact(
-                    filepath, env
-                )
-                yield pxml_content_bytes, filepath
-            except Exception:
-                logger.error(f"Failed to get PXML file {filepath} as fallback")
-                pass
+            raise


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Improve error handling in artifact processing by raising specific errors instead of using fallbacks in `artifacts.py` and `routes/artifacts.py`.
> 
>   - **Error Handling**:
>     - In `artifacts.py`, `get_files_for_pxml()` now raises an error if no CSV files are found, removing the fallback mechanism.
>     - In `routes/artifacts.py`, `save_artifact()` raises a specific error message when saving creations fails.
>     - In `routes/artifacts.py`, `serve_artifact_file()` raises an error if PXML to HTML conversion fails, instead of falling back.
>   - **Logging**:
>     - Improved logging for error scenarios in `artifacts.py` and `routes/artifacts.py` to provide more specific error messages.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=sinaptik-ai%2Fpanda-agi&utm_source=github&utm_medium=referral)<sup> for e011e24cf06552796c268088c4cd3dae638be861. You can [customize](https://app.ellipsis.dev/sinaptik-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->