### PR TITLE
fix: on created preview pxml correctly

### DIFF
--- a/examples/ui/frontend/src/components/events/file-read.tsx
+++ b/examples/ui/frontend/src/components/events/file-read.tsx
@@ -53,6 +53,7 @@ const FileReadEvent: React.FC<FileReadEventProps> = ({
 
   const handlePreviewClick = () => {
     if (onPreviewClick && filename) {
+      const fileType = getFileType(filename);
       onPreviewClick({
         filename: filename,
         title: filename.split("/").pop(),

--- a/examples/ui/frontend/src/components/events/file-write.tsx
+++ b/examples/ui/frontend/src/components/events/file-write.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { FileText, Eye } from "lucide-react";
+import { getFileType } from "@/lib/utils";
 
 interface FileWriteEventProps {
   payload?: {
@@ -32,48 +33,7 @@ const FileWriteEvent: React.FC<FileWriteEventProps> = ({
   };
 
   const handlePreviewClick = () => {
-    if (onPreviewClick && filename) {
-      const getFileType = (filePath: string): string => {
-        if (!filePath) return "text";
-        const extension = filePath.split(".").pop()?.toLowerCase();
-        if (extension && ["csv", "xls", "xlsx"].includes(extension))
-          return "table";
-        if (extension && ["md", "markdown", "txt"].includes(extension))
-          return "markdown";
-        if (extension && ["html", "htm"].includes(extension)) return "html";
-        if (
-          extension &&
-          [
-            "js",
-            "jsx",
-            "ts",
-            "tsx",
-            "py",
-            "java",
-            "c",
-            "cpp",
-            "go",
-            "rb",
-            "php",
-            "css",
-            "scss",
-            "json",
-            "xml",
-            "yaml",
-            "yml",
-          ].includes(extension)
-        )
-          return "code";
-        if (
-          extension &&
-          ["jpg", "jpeg", "png", "gif", "svg", "webp", "bmp"].includes(
-            extension
-          )
-        )
-          return "image";
-        if (extension === "pdf") return "pdf";
-        return "text";
-      };
+    if (onPreviewClick && filename) { 
 
       onPreviewClick({
         filename: filePath,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Refactor `getFileType` usage in `file-read.tsx` and `file-write.tsx` to import from `@/lib/utils`, removing inline definitions.
> 
>   - **Refactoring**:
>     - `getFileType` function is now imported from `@/lib/utils` in `file-read.tsx` and `file-write.tsx` instead of being defined inline.
>     - Removed inline `getFileType` function definition in `file-write.tsx`.
>   - **Behavior**:
>     - No change in behavior; the refactor ensures consistent file type determination across components.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=sinaptik-ai%2Fpanda-agi&utm_source=github&utm_medium=referral)<sup> for 33d51bf4354f48d085a52afa2e831bb894ee866d. You can [customize](https://app.ellipsis.dev/sinaptik-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->