### PR TITLE
fix: param file_name tool edit

### DIFF
--- a/examples/ui/backend/panda_agi/tools/file_system.py
+++ b/examples/ui/backend/panda_agi/tools/file_system.py
@@ -1,5 +1,4 @@
 from typing import Any, Dict, Optional
-import xml
 
 from pxml.xml_parser import XMLParser
 
@@ -14,7 +13,6 @@ from .file_system_ops.file_ops import (
     file_write,
 )
 from .registry import ToolRegistry
-import re
 
 
 @ToolRegistry.register(
@@ -136,10 +134,6 @@ class FileReplaceHandler(ToolHandler):
             "old_str": params["find_str"],
             "new_str": params["replace_str"],
         }
-
-        # Map the XML parameter names to the function parameter names TODO: improve this
-        mapped_params["file"] = mapped_params["file_name"]
-        del mapped_params["file_name"]
         result = await file_str_replace(self.environment, **mapped_params)
         await self.add_event(EventType.FILE_REPLACE, params)
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Simplified parameter handling in `FileReplaceHandler` and removed unused imports in `file_system.py`.
> 
>   - **Code Simplification**:
>     - Removed unnecessary parameter mapping in `execute()` of `FileReplaceHandler` in `file_system.py`.
>     - Directly uses `file_name` parameter without remapping to `file`.
>   - **Imports**:
>     - Removed unused imports `xml` and `re` from `file_system.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=sinaptik-ai%2Fpanda-agi&utm_source=github&utm_medium=referral)<sup> for 5cd2107270eeb8033de9bdd305c1300d02d8a88f. You can [customize](https://app.ellipsis.dev/sinaptik-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->