### PR TITLE
fix: raise error after file write

### DIFF
--- a/examples/ui/backend/panda_agi/tools/file_system.py
+++ b/examples/ui/backend/panda_agi/tools/file_system.py
@@ -81,18 +81,6 @@ class FileWriteHandler(ToolHandler):
         if file_extension not in self.VALID_FILE_EXTENSIONS:
             return f"Invalid file extension: {file_extension}. Valid extensions: {', '.join(self.VALID_FILE_EXTENSIONS)}"
 
-        if file_extension == ".pxml":
-            try:
-                xml_parser = XMLParser()
-                # Validation if parsing is successful
-                xml_parser.parse(params["content"])
-            except Exception as e:
-                logger.error(
-                    f"Invalid PXML content provided for file write: {params['content']} | Exception: {e}"
-                )
-                return f"Invalid PXML file: {e}. Failed to write the file. Please verify the file content and try again after correcting any issues."
-            return
-
         return None
 
     async def execute(self, params: Dict[str, Any]) -> ToolResult:
@@ -104,6 +92,24 @@ class FileWriteHandler(ToolHandler):
         message = ""
 
         if result.get("status") == "success":
+
+            file_extension = "." + params.get("file", "").split(".")[-1]
+
+            if file_extension == ".pxml":
+                try:
+                    xml_parser = XMLParser()
+                    # Validation if parsing is successful
+                    xml_parser.parse(params["content"])
+                except Exception as e:
+                    logger.error(
+                        f"Invalid PXML content provided for file write: {params['content']} | Exception: {e}"
+                    )
+                    return ToolResult(
+                        success=False,
+                        data=None,
+                        error=f"Invalid PXML file: {e}. Failed to write the file. Please verify the file content and try again after correcting any issues.",
+                    )
+
             mode = result.get("mode", "overwrite")
             if mode == "append":
                 message = "Successfully appended content to file."

--- a/examples/ui/backend/panda_agi/tools/file_system.py
+++ b/examples/ui/backend/panda_agi/tools/file_system.py
@@ -16,7 +16,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 # Global error message for file validation failures
-FILE_VALIDATION_ERROR_MSG = "File saved successfully, but validation failed: \n{e}. \n\n Please verify and correct the file content before continuing."
+FILE_VALIDATION_ERROR_MSG = "File saved successfully but content validation failed: {e}. Please verify and correct the file content before continuing."
 
 
 @ToolRegistry.register(

--- a/examples/ui/backend/panda_agi/tools/file_system.py
+++ b/examples/ui/backend/panda_agi/tools/file_system.py
@@ -107,7 +107,7 @@ class FileWriteHandler(ToolHandler):
                     return ToolResult(
                         success=False,
                         data=None,
-                        error=f"Invalid PXML file: {e}. Failed to write the file. Please verify the file content and try again after correcting any issues.",
+                        error=f"The provided PXML content is invalid: {e}. Please verify the file content and try again after correcting any issues.",
                     )
 
             mode = result.get("mode", "overwrite")

--- a/examples/ui/backend/panda_agi/tools/file_system.py
+++ b/examples/ui/backend/panda_agi/tools/file_system.py
@@ -169,7 +169,7 @@ class FileReplaceHandler(ToolHandler):
                     xml_parser.parse(file_content["content"])
                 except Exception as e:
                     logger.error(
-                        f"""Exception: {e} | Invalid PXML content provided for file write: {file_content["content"]}"""
+                        f"""Exception: {e} | Invalid PXML content provided for file replace: {file_content["content"]}"""
                     )
                     return ToolResult(
                         success=False,

--- a/examples/ui/backend/panda_agi/tools/file_system.py
+++ b/examples/ui/backend/panda_agi/tools/file_system.py
@@ -15,6 +15,9 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+# Global error message for file validation failures
+FILE_VALIDATION_ERROR_MSG = "File saved successfully, but validation failed: \n{e}. \n\n Please verify and correct the file content before continuing."
+
 
 @ToolRegistry.register(
     "file_read",
@@ -102,12 +105,12 @@ class FileWriteHandler(ToolHandler):
                     xml_parser.parse(params["content"])
                 except Exception as e:
                     logger.error(
-                        f"Invalid PXML content provided for file write: {params['content']} | Exception: {e}"
+                        f"Exception: {e} | Invalid PXML content provided for file write: {params['content']}"
                     )
                     return ToolResult(
                         success=False,
                         data=None,
-                        error=f"The provided PXML content is invalid: {e}. Please verify the file content and try again after correcting any issues.",
+                        error=FILE_VALIDATION_ERROR_MSG.format(e=e),
                     )
 
             mode = result.get("mode", "overwrite")
@@ -157,6 +160,23 @@ class FileReplaceHandler(ToolHandler):
             "new_str": params["replace_str"],
         }
         result = await file_str_replace(self.environment, **mapped_params)
+        if result.get("status") == "success":
+            file_content = await file_read(self.environment, file=params["file_name"])
+            file_extension = "." + params.get("file_name", "").split(".")[-1]
+            if file_extension == ".pxml":
+                try:
+                    xml_parser = XMLParser()
+                    xml_parser.parse(file_content["content"])
+                except Exception as e:
+                    logger.error(
+                        f"""Exception: {e} | Invalid PXML content provided for file write: {file_content["content"]}"""
+                    )
+                    return ToolResult(
+                        success=False,
+                        data=None,
+                        error=FILE_VALIDATION_ERROR_MSG.format(e=e),
+                    )
+
         await self.add_event(EventType.FILE_REPLACE, params)
 
         return ToolResult(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Moves `.pxml` validation to post-write in `FileWriteHandler` and `FileReplaceHandler`, raising errors if validation fails.
> 
>   - **Behavior**:
>     - Moves `.pxml` validation from `validate_input` to `execute` in `FileWriteHandler` and `FileReplaceHandler`.
>     - Raises error with `FILE_VALIDATION_ERROR_MSG` if `.pxml` validation fails after file write.
>   - **Logging**:
>     - Logs error with specific exception details if `.pxml` validation fails in `execute` methods.
>   - **Misc**:
>     - Removes `.pxml` validation from `validate_input` in `FileWriteHandler`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=sinaptik-ai%2Fpanda-agi&utm_source=github&utm_medium=referral)<sup> for 7407d987576732f1e727f61e26e49bc88f5afe20. You can [customize](https://app.ellipsis.dev/sinaptik-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->