### PR TITLE
feat: use agent state to track number of correction attempts and limi them to 3

### DIFF
--- a/examples/ui/backend/panda_agi/client/agent.py
+++ b/examples/ui/backend/panda_agi/client/agent.py
@@ -110,8 +110,6 @@ class Agent:
             use_image_generation=use_image_generation,
         )
 
-        # self.event_manager = EventManager()
-
         # Initialize tool registry and create handlers
         self.tool_registry = ToolRegistry()
         self.tool_handlers = self._create_handlers()
@@ -150,7 +148,6 @@ class Agent:
         for handler in handlers.values():
             handler.set_agent(self)
             handler.set_environment(self.environment)
-            # handler.set_event_manager(self.event_manager)
 
         return handlers
 

--- a/examples/ui/backend/panda_agi/client/state.py
+++ b/examples/ui/backend/panda_agi/client/state.py
@@ -15,3 +15,6 @@ class AgentState:
 
         # environment
         self.filesystem: Dict = {}
+
+        # tools state
+        self.tools_state: Dict = {}

--- a/examples/ui/backend/panda_agi/tools/base.py
+++ b/examples/ui/backend/panda_agi/tools/base.py
@@ -49,6 +49,36 @@ class ToolHandler(ABC):
 
         await self.event_manager.add_event(event_type, data)
 
+    def increment_file_error_count(
+        self, filename: str, operation_type: str = "file_operation"
+    ):
+        """Increment error count for a file operation."""
+        if not self.agent:
+            return
+        self.agent.state.tools_state.setdefault("file_errors", {})
+        file_state = self.agent.state.tools_state["file_errors"].setdefault(
+            filename, {"num_errors": 0}
+        )
+        file_state["num_errors"] += 1
+
+    def get_file_error_count(self, filename: str) -> int:
+        """Get the current error count for a file."""
+        if not self.agent:
+            return 0
+        return (
+            self.agent.state.tools_state.get("file_errors", {})
+            .get(filename, {"num_errors": 0})
+            .get("num_errors", 0)
+        )
+
+    def reset_file_error_count(self, filename: str):
+        """Reset error count for a file."""
+        if not self.agent:
+            return
+        self.agent.state.tools_state.setdefault("file_errors", {}).setdefault(
+            filename, {"num_errors": 0}
+        )["num_errors"] = 0
+
     def validate_input(self, params: Dict[str, Any]) -> Optional[str]:
         """Validate input parameters. Return error message if invalid, None if valid"""
         return None

--- a/examples/ui/backend/panda_agi/tools/file_system.py
+++ b/examples/ui/backend/panda_agi/tools/file_system.py
@@ -1,5 +1,8 @@
+import logging
 from typing import Any, Dict, Optional
+
 from pxml.xml_parser import XMLParser
+
 from ..client.models import EventType
 from .base import ToolHandler, ToolResult
 from .file_system_ops.file_ops import (
@@ -11,12 +14,13 @@ from .file_system_ops.file_ops import (
     file_write,
 )
 from .registry import ToolRegistry
-import logging
 
 logger = logging.getLogger(__name__)
 
 # Global error message for file validation failures
-FILE_VALIDATION_ERROR_MSG = "File saved successfully but content validation failed: {e}. Please verify and correct the file content before continuing."
+FILE_VALIDATION_ERROR_MSG = "File saved successfully but content validation failed: {e}. Correct the file content."
+STOP_FILE_CORRECTION_MSG = "You have exceeded the maximum number of file correction attempts. Abort the correction process."
+MAX_FILE_CORRECTION_ATTEMPTS = 3
 
 
 @ToolRegistry.register(
@@ -95,7 +99,6 @@ class FileWriteHandler(ToolHandler):
         message = ""
 
         if result.get("status") == "success":
-
             file_extension = "." + params.get("file", "").split(".")[-1]
 
             if file_extension == ".pxml":
@@ -107,6 +110,16 @@ class FileWriteHandler(ToolHandler):
                     logger.error(
                         f"Exception: {e} | Invalid PXML content provided for file write: {params['content']}"
                     )
+                    if (
+                        self.get_file_error_count(params["file"])
+                        >= MAX_FILE_CORRECTION_ATTEMPTS
+                    ):
+                        return ToolResult(
+                            success=False,
+                            data=None,
+                            error=STOP_FILE_CORRECTION_MSG,
+                        )
+                    self.increment_file_error_count(params["file"])
                     return ToolResult(
                         success=False,
                         data=None,
@@ -171,6 +184,16 @@ class FileReplaceHandler(ToolHandler):
                     logger.error(
                         f"""Exception: {e} | Invalid PXML content provided for file replace: {file_content["content"]}"""
                     )
+                    if (
+                        self.get_file_error_count(params["file_name"])
+                        >= MAX_FILE_CORRECTION_ATTEMPTS
+                    ):
+                        return ToolResult(
+                            success=False,
+                            data=None,
+                            error=STOP_FILE_CORRECTION_MSG,
+                        )
+                    self.increment_file_error_count(params["file_name"])
                     return ToolResult(
                         success=False,
                         data=None,

--- a/examples/ui/backend/panda_agi/tools/shell.py
+++ b/examples/ui/backend/panda_agi/tools/shell.py
@@ -169,6 +169,8 @@ class ExecuteScriptHandler(ToolHandler):
             "time",
             "random",
             "math",
+            "warnings",
+            "logging",
         ]
 
         # Search for import statements (import <lib_name> or from <lib_name> import <any>)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Track and limit file correction attempts to 3 using agent state, with updates to file operation handlers and state management.
> 
>   - **Behavior**:
>     - Track file correction attempts using `tools_state` in `AgentState`.
>     - Limit file correction attempts to 3 in `FileWriteHandler` and `FileReplaceHandler`.
>     - Return error message `STOP_FILE_CORRECTION_MSG` after 3 attempts.
>   - **State Management**:
>     - Add `tools_state` to `AgentState` in `state.py`.
>     - Implement `increment_file_error_count()`, `get_file_error_count()`, and `reset_file_error_count()` in `ToolHandler`.
>   - **Misc**:
>     - Remove commented-out `event_manager` code in `agent.py`.
>     - Add `warnings` and `logging` to allowed libraries in `ExecuteScriptHandler` in `shell.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=sinaptik-ai%2Fpanda-agi&utm_source=github&utm_medium=referral)<sup> for 01c9bdf6ce28038a2dfbd866beb04760420419b9. You can [customize](https://app.ellipsis.dev/sinaptik-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->