### PR TITLE
fix: open pxml on file edit

### DIFF
--- a/examples/ui/frontend/src/components/events/file-replace.tsx
+++ b/examples/ui/frontend/src/components/events/file-replace.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { FileText, Eye } from "lucide-react";
+import { getFileType } from "@/lib/utils";
 
 interface FileReplaceEventProps {
   payload?: {
@@ -32,54 +33,14 @@ const FileReplaceEvent: React.FC<FileReplaceEventProps> = ({
 
   const handlePreviewClick = () => {
     if (onPreviewClick && filename) {
-      const getFileType = (filePath: string): string => {
-        if (!filePath) return "text";
-        const extension = filePath.split(".").pop()?.toLowerCase();
-        if (extension && ["csv", "xls", "xlsx"].includes(extension))
-          return "table";
-        if (extension && ["md", "markdown", "txt"].includes(extension))
-          return "markdown";
-        if (extension && ["html", "htm"].includes(extension)) return "html";
-        if (
-          extension &&
-          [
-            "js",
-            "jsx",
-            "ts",
-            "tsx",
-            "py",
-            "java",
-            "c",
-            "cpp",
-            "go",
-            "rb",
-            "php",
-            "css",
-            "scss",
-            "json",
-            "xml",
-            "yaml",
-            "yml",
-          ].includes(extension)
-        )
-          return "code";
-        if (
-          extension &&
-          ["jpg", "jpeg", "png", "gif", "svg", "webp", "bmp"].includes(
-            extension
-          )
-        )
-          return "image";
-        if (extension === "pdf") return "pdf";
-        return "text";
-      };
-
+    
       onPreviewClick({
         filename: filename,
         title: filename.split("/").pop(),
         type: getFileType(filename),
         timestamp: timestamp,
       });
+      
     }
   };
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor `getFileType` function in `file-replace.tsx` to import from `@/lib/utils`, improving code maintainability.
> 
>   - **Refactoring**:
>     - Move `getFileType` function from inline definition in `handlePreviewClick` to import from `@/lib/utils` in `file-replace.tsx`.
>   - **Behavior**:
>     - No change in behavior; `getFileType` still determines file type based on extension in `handlePreviewClick`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=sinaptik-ai%2Fpanda-agi&utm_source=github&utm_medium=referral)<sup> for 3dbf33fbde8679c57669a79b014ba0aef70ccf97. You can [customize](https://app.ellipsis.dev/sinaptik-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->