### PR TITLE
fix: reset values on close of modal

### DIFF
--- a/examples/ui/frontend/src/components/dashboard-modal-preview.tsx
+++ b/examples/ui/frontend/src/components/dashboard-modal-preview.tsx
@@ -46,7 +46,12 @@ const DashboardModalPreview: React.FC<DashboardModalPreviewProps> = ({
   // Suggested name state
   const [suggestedName, setSuggestedName] = useState<string>("");
 
-
+  const handleClose = () => {
+    setIsSaved(false);
+    setSavedArtifact(null);
+    setSuggestedName("");
+    onClose();
+  };
 
   // Function to check for existing saved artifact
   const checkExistingArtifact = () => {
@@ -265,7 +270,7 @@ const DashboardModalPreview: React.FC<DashboardModalPreviewProps> = ({
       removeArtifact(previewData.filename, previewData.timestamp);
     }
 
-    onClose();
+    handleClose();
   };
 
   // Handle title change
@@ -331,7 +336,7 @@ const DashboardModalPreview: React.FC<DashboardModalPreviewProps> = ({
         artifact={savedArtifact}
         onArtifactUpdated={handleArtifactUpdated}
         onArtifactDeleted={handleArtifactDeleted}
-        onClose={onClose}
+        onClose={handleClose}
         isSaved={isSaved}
         previewData={previewData}
         conversationId={conversationId}
@@ -344,7 +349,7 @@ const DashboardModalPreview: React.FC<DashboardModalPreviewProps> = ({
   return (
     <ModalWrapper
       isOpen={isOpen}
-      onClose={onClose}
+      onClose={handleClose}
       title={
         suggestedName ||
         previewData.title ||


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `handleClose` function to reset modal state on close in `dashboard-modal-preview.tsx`.
> 
>   - **Behavior**:
>     - Adds `handleClose` function in `dashboard-modal-preview.tsx` to reset `isSaved`, `savedArtifact`, and `suggestedName` on modal close.
>     - Replaces `onClose` with `handleClose` in `handleArtifactDeleted`, `ArtifactActions`, and `ModalWrapper` to ensure state reset on close.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=sinaptik-ai%2Fpanda-agi&utm_source=github&utm_medium=referral)<sup> for 034484008057318aa53fcec6ebbc23d98d445b2b. You can [customize](https://app.ellipsis.dev/sinaptik-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->