### PR TITLE
feat: add limit of 10 MB size to csv file

### DIFF
--- a/examples/ui/frontend/src/components/chatbox.tsx
+++ b/examples/ui/frontend/src/components/chatbox.tsx
@@ -284,11 +284,7 @@ const ChatBox = forwardRef<ChatBoxRef, ChatBoxProps>(
         // Show error message for oversized files
         if (oversizedFiles.length > 0) {
           toast.error(
-            `File${
-              oversizedFiles.length > 1 ? "s" : ""
-            } too large: ${oversizedFiles.map(f => f.name).join(", ")} ${
-              oversizedFiles.length > 1 ? "are" : "is"
-            } larger than 10MB.`
+            `The file you are uploading exceed the maximum filesize of 10 megabytes`
           );
         }
 

--- a/examples/ui/frontend/src/components/chatbox.tsx
+++ b/examples/ui/frontend/src/components/chatbox.tsx
@@ -296,7 +296,7 @@ const ChatBox = forwardRef<ChatBoxRef, ChatBoxProps>(
         // Create new file previews to add to existing ones (cumulative)
         const baseId = Date.now();
         const newFilePreviews = await Promise.all(
-          Array.from(validSizeFiles).map(async (file, index) => {
+          validSizeFiles.map(async (file, index) => {
             let content = undefined;
 
             // Read CSV files for preview

--- a/examples/ui/frontend/src/components/chatbox.tsx
+++ b/examples/ui/frontend/src/components/chatbox.tsx
@@ -284,7 +284,7 @@ const ChatBox = forwardRef<ChatBoxRef, ChatBoxProps>(
         // Show error message for oversized files
         if (oversizedFiles.length > 0) {
           toast.error(
-            `The file you are uploading exceed the maximum filesize of 10 megabytes`
+            `The file you are uploading exceeds the maximum file size of 10 megabytes`
           );
         }
 

--- a/examples/ui/frontend/src/components/chatbox.tsx
+++ b/examples/ui/frontend/src/components/chatbox.tsx
@@ -267,6 +267,11 @@ const ChatBox = forwardRef<ChatBoxRef, ChatBoxProps>(
           (file) => !file.name.toLowerCase().endsWith(".csv")
         );
 
+        // Filter files by size (10MB limit)
+        const maxSizeInBytes = 10 * 1024 * 1024; // 10MB
+        const validSizeFiles = csvFiles.filter((file) => file.size <= maxSizeInBytes);
+        const oversizedFiles = csvFiles.filter((file) => file.size > maxSizeInBytes);
+
         // Show error message for non-CSV files
         if (nonCsvFiles.length > 0) {
           toast.error(
@@ -274,17 +279,28 @@ const ChatBox = forwardRef<ChatBoxRef, ChatBoxProps>(
               nonCsvFiles.length > 1 ? "s" : ""
             }: only CSV files are allowed.`
           );
+        }
 
-          // If no CSV files, return early
-          if (csvFiles.length === 0) {
-            return;
-          }
+        // Show error message for oversized files
+        if (oversizedFiles.length > 0) {
+          toast.error(
+            `File${
+              oversizedFiles.length > 1 ? "s" : ""
+            } too large: ${oversizedFiles.map(f => f.name).join(", ")} ${
+              oversizedFiles.length > 1 ? "are" : "is"
+            } larger than 10MB.`
+          );
+        }
+
+        // If no valid files, return early
+        if (validSizeFiles.length === 0) {
+          return;
         }
 
         // Create new file previews to add to existing ones (cumulative)
         const baseId = Date.now();
         const newFilePreviews = await Promise.all(
-          Array.from(csvFiles).map(async (file, index) => {
+          Array.from(validSizeFiles).map(async (file, index) => {
             let content = undefined;
 
             // Read CSV files for preview
@@ -310,7 +326,7 @@ const ChatBox = forwardRef<ChatBoxRef, ChatBoxProps>(
         setUploadingFiles(true);
 
         try {
-          const uploadPromises = Array.from(files).map(async (file, index) => {
+          const uploadPromises = Array.from(validSizeFiles).map(async (file, index) => {
             const filePreviewId = newFilePreviews[index].id;
 
             try {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds a 10MB size limit for CSV file uploads in the `ChatBox` component, filtering out oversized files and displaying an error message.
> 
>   - **Behavior**:
>     - Adds a 10MB size limit for CSV files in `ChatBox` component.
>     - Filters out files exceeding 10MB and shows error message using `toast.error()`.
>     - Updates file processing logic to handle only valid size files.
>   - **Functions**:
>     - Modifies `handleFilesUpload()` to filter files by size and handle oversized files.
>     - Updates file preview and upload logic to use `validSizeFiles` instead of `csvFiles`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=sinaptik-ai%2Fpanda-agi&utm_source=github&utm_medium=referral)<sup> for 308726a701a473eecb255df1d58b94016cbf6798. You can [customize](https://app.ellipsis.dev/sinaptik-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->