### PR TITLE
fix: update credit on set_idle state as well

### DIFF
--- a/examples/ui/frontend/src/components/chatbox.tsx
+++ b/examples/ui/frontend/src/components/chatbox.tsx
@@ -722,7 +722,7 @@ const ChatBox = forwardRef<ChatBoxRef, ChatBoxProps>(
                   // Check if conversation is completed
                   if (
                     eventData.data &&
-                    (eventData.data.tool_name === "completed_task" ||
+                    (eventData.data.tool_name === "completed_task" || eventData.data.tool_name === "set_idle" ||
                       ["exception", "error"].includes(
                         eventData.data.event_type
                       ))

--- a/examples/ui/frontend/src/components/chatbox.tsx
+++ b/examples/ui/frontend/src/components/chatbox.tsx
@@ -722,7 +722,7 @@ const ChatBox = forwardRef<ChatBoxRef, ChatBoxProps>(
                   // Check if conversation is completed
                   if (
                     eventData.data &&
-                    (eventData.data.tool_name === "completed_task" || eventData.data.tool_name === "set_idle" ||
+                    (eventData.data.tool_name === "set_idle" ||
                       ["exception", "error"].includes(
                         eventData.data.event_type
                       ))

--- a/examples/ui/frontend/src/components/event-list.tsx
+++ b/examples/ui/frontend/src/components/event-list.tsx
@@ -181,7 +181,7 @@ const EventList: React.FC<EventListProps> = ({
       timestamp:message.event.timestamp
     };
     return <Component {...componentProps} />;
-  } else if (!["completed_task"].includes(eventType)) {
+  } else if (!["set_idle"].includes(eventType)) {
     // Use ToolUseEvent as fallback for any unknown tool
     const toolPayload = {
       tool_name: eventType,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Handle `set_idle` event type in `ChatBox` and `EventList` components for credit refetching and event handling.
> 
>   - **Behavior**:
>     - Update `ChatBox` in `chatbox.tsx` to handle `set_idle` event type for credit refetching when conversation is completed.
>     - Modify `EventList` in `event-list.tsx` to exclude `set_idle` from fallback handling, treating it as a known event type.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=sinaptik-ai%2Fpanda-agi&utm_source=github&utm_medium=referral)<sup> for 5c83e8db6a07b31d9fa6ba355542360258c7aa21. You can [customize](https://app.ellipsis.dev/sinaptik-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->