### PR TITLE
fix: get creation user plan

### DIFF
--- a/examples/ui/backend/routes/artifacts.py
+++ b/examples/ui/backend/routes/artifacts.py
@@ -51,6 +51,25 @@ ERROR_PAGE_URL = f"{PANDA_CHAT_CLIENT_URL}/404"
 router = APIRouter(prefix="/artifacts", tags=["artifacts"])
 
 
+async def get_artifact_user_plan(artifact_id: str):
+    """Get the current user's subscription"""
+
+    async with aiohttp.ClientSession() as session:
+
+        async with session.get(
+            f"{PANDA_AGI_SERVER_URL}/artifacts/{artifact_id}/user-package",
+        ) as resp:
+            if resp.status == 404:
+                # User has no subscription
+                return {"current_package": None}
+            elif resp.status != 200:
+                raise HTTPException(
+                    status_code=resp.status, detail="Failed to fetch subscription"
+                )
+
+            return await resp.json()
+
+
 async def process_artifact_markdown_to_pdf(
     file_path: str,
     content_bytes: bytes,
@@ -615,7 +634,10 @@ async def serve_artifact_file(
                 # Check if it's a pxml file and raw mode is not requested
                 if file_path.lower().endswith((".pxml")):
                     if not raw:
-                        subscription_package = await get_subscription_package(api_key)
+                        subscription_package = await get_artifact_user_plan(artifact_id)
+                        subscription_package = subscription_package.get(
+                            "current_package"
+                        )
                         html_response = await process_artifact_pxml_to_html(
                             file_path,
                             content_bytes,

--- a/examples/ui/backend/routes/artifacts.py
+++ b/examples/ui/backend/routes/artifacts.py
@@ -51,7 +51,7 @@ ERROR_PAGE_URL = f"{PANDA_CHAT_CLIENT_URL}/404"
 router = APIRouter(prefix="/artifacts", tags=["artifacts"])
 
 
-async def get_artifact_user_plan(artifact_id: str):
+async def get_artifact_user_plan(artifact_id: str) -> dict:
     """Get the current user's subscription"""
 
     async with aiohttp.ClientSession() as session:

--- a/examples/ui/backend/services/files.py
+++ b/examples/ui/backend/services/files.py
@@ -3,7 +3,7 @@ import mimetypes
 import os
 from pathlib import Path
 
-from panda_agi.utils import file_replace
+from panda_agi.utils.file_replace import file_replace
 from models.agent import ConversationMessage
 from panda_agi.envs.base_env import BaseEnv
 from utils.exceptions import FileNotFoundError, RestrictedAccessError


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `get_artifact_user_plan` to fetch user subscription plans for artifacts and updates `serve_artifact_file` to use it for PXML processing.
> 
>   - **Behavior**:
>     - Adds `get_artifact_user_plan()` in `artifacts.py` to fetch user's subscription plan for an artifact.
>     - Updates `serve_artifact_file()` in `artifacts.py` to use `get_artifact_user_plan()` for determining subscription package when processing PXML files.
>   - **Imports**:
>     - Changes import of `file_replace` in `files.py` to be more specific.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=sinaptik-ai%2Fpanda-agi&utm_source=github&utm_medium=referral)<sup> for 9756c3f467d803a46e2f7a15bd998d3c9900816f. You can [customize](https://app.ellipsis.dev/sinaptik-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->